### PR TITLE
fix: `forwardemail.net` is a secure/privacy-focused provider (ref: https://forwardemail.net and whitepaper at https://forwardemail.net/technical-whitepaper.pdf) (closes #4)

### DIFF
--- a/src/disposable-email-providers.json
+++ b/src/disposable-email-providers.json
@@ -58872,7 +58872,6 @@
   "forward.modafe.design",
   "forward4families.org",
   "forward50.us",
-  "forwardemail.net",
   "forwardhome.app",
   "forwardshop.pro",
   "forwardshop.site",

--- a/src/domain-suggester.ts
+++ b/src/domain-suggester.ts
@@ -28,6 +28,7 @@ export const COMMON_EMAIL_DOMAINS = [
   'amazonaws.com',
 
   // Secure/Privacy-focused providers
+  'forwardemail.net',
   'tutanota.com',
   'tuta.com',
   'fastmail.com',


### PR DESCRIPTION
`forwardemail.net` is a secure/privacy-focused provider (ref: https://forwardemail.net and whitepaper at https://forwardemail.net/technical-whitepaper.pdf) (closes #4)