### PR TITLE
fix: re-export verifyMailboxSMTP + missing utilities from main entry

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,26 +5,40 @@
  * (`isDisposableEmail`, `isFreeEmail`) live in their own modules so
  * `batch-verifier.ts` can pull `verifyEmail` directly without going through
  * this file. That broke a `index → batch-verifier → index` Rollup cycle.
+ *
+ * Anything `export`ed under `src/*.ts` should also be re-exported here so
+ * `import { … } from '@emailcheck/email-validator-js'` works for every
+ * public symbol. See the audit comment per-line below.
  */
 
+// Cache adapters (LRU, Redis) + the cache interface + default cache helpers.
 export * from './adapters/lru-adapter';
 export * from './adapters/redis-adapter';
+// Top-level orchestrators.
 export { verifyEmailBatch } from './batch-verifier';
 export * from './cache';
 export * from './cache-interface';
+// Domain-suggestion utilities (sync + async + similarity scoring).
 export {
   commonEmailDomains,
   defaultDomainSuggestionMethod,
+  defaultDomainSuggestionMethodAsync,
   getDomainSimilarity,
   isCommonDomain,
   suggestDomain,
   suggestEmailDomain,
 } from './domain-suggester';
+
+// Direct subsystem APIs — callers can use these without going through
+// `verifyEmail` when they only need one piece (MX lookup, SMTP probe,
+// disposable / free check, WHOIS, syntax validation, etc.).
 export { isValidEmail, isValidEmailDomain } from './email-validator';
 export { isDisposableEmail } from './is-disposable-email';
 export { isFreeEmail } from './is-free-email';
 export { isSpamEmail } from './is-spam-email';
 export { isSpamName } from './is-spam-name';
+export { resolveMxRecords } from './mx-resolver';
+// Name-detection utilities (default heuristic + algorithm-clean variants).
 export {
   cleanNameForAlgorithm,
   defaultNameDetectionMethod,
@@ -32,13 +46,18 @@ export {
   detectNameForAlgorithm,
   detectNameFromEmail,
 } from './name-detector';
+// Pure utilities (no I/O) for parsing / classifying SMTP error strings.
 export { type ParsedSmtpError, parseSmtpError } from './smtp-error-parser';
+export { type ParsedDsn, parseDsn, verifyMailboxSMTP } from './smtp-verifier';
+// Transcript collector primitives — opt-in pipeline tracing.
 export {
   ArrayTranscriptCollector,
   NULL_COLLECTOR,
   type TranscriptCollector,
 } from './transcript';
-// Re-export types
+// All type definitions live in one module; re-export everything so callers
+// can import any of them directly from the package root.
 export * from './types';
 export { domainPorts, verifyEmail } from './verify-email';
 export { getDomainAge, getDomainRegistrationStatus } from './whois';
+export { type ParsedWhoisResult, parseWhoisData } from './whois-parser';


### PR DESCRIPTION
## Summary

`verifyMailboxSMTP` (the direct SMTP-probe API the package is built around) and a handful of other utility exports weren't reachable from `'@emailcheck/email-validator-js'`. They lived in their submodules but were never re-exported from the barrel `src/index.ts`. With the package's strict `exports` map, deep imports like `'@emailcheck/email-validator-js/src/smtp-verifier'` aren't a viable workaround — so this was a hard reachability bug, not just a minor inconvenience.

## What changed

Added re-exports for everything that's `export`ed under `src/*.ts` but wasn't on the root barrel:

| Symbol | Why it should be public |
| --- | --- |
| **`verifyMailboxSMTP`** | Direct SMTP probe — primary consumer-facing function |
| `parseDsn` + `ParsedDsn` | RFC 3463 enhanced-status parser (no I/O) |
| `parseWhoisData` + `ParsedWhoisResult` | TLD-aware WHOIS parser for callers who fetch WHOIS themselves |
| `resolveMxRecords` | MX lookup with cache for callers that don't need full `verifyEmail` |
| `defaultDomainSuggestionMethodAsync` | Async variant of the already-exported sync default — consistency fix |

Reorganised `src/index.ts` so each section has a one-line audit comment. Tracking rule: anything `export`ed under `src/*.ts` (top-level, non-cli, non-serverless) re-exports through this barrel.

## Verification

- [x] `bun run typecheck` — clean
- [x] `bun run test` — 800 unit + 37 isolated passing
- [x] `bun run test:extras` — 206 / 1 skip / 0 fail
- [x] `bun run build` — zero rollup warnings, all bundles produced
- [x] Runtime smoke test against `dist/index.js` — every expected symbol resolves (38 names checked: `verifyEmail`, `verifyEmailBatch`, `verifyMailboxSMTP`, `isValidEmail`, `isValidEmailDomain`, `isDisposableEmail`, `isFreeEmail`, `isSpamEmail`, `isSpamName`, `resolveMxRecords`, `getDomainAge`, `getDomainRegistrationStatus`, `parseSmtpError`, `parseDsn`, `parseWhoisData`, `suggestDomain`, `suggestEmailDomain`, `isCommonDomain`, `getDomainSimilarity`, `commonEmailDomains`, `defaultDomainSuggestionMethod`, `defaultDomainSuggestionMethodAsync`, `detectName`, `detectNameFromEmail`, `detectNameForAlgorithm`, `cleanNameForAlgorithm`, `defaultNameDetectionMethod`, `ArrayTranscriptCollector`, `NULL_COLLECTOR`, `getDefaultCache`, `clearDefaultCache`, `getCacheStore`, `LRUAdapter`, `RedisAdapter`, `domainPorts`, `VerificationErrorCode`, `EmailProvider`, `SMTPStep`)

## Merge note

This is a `fix:` commit — semantic-release will tag a patch release on merge to master. No breaking changes.

When merging, **use a regular merge commit** (or rebase-and-merge), not squash — squashing collapses the commit message into the PR title, which is fine in this case (`fix:` prefix preserved), but a regular merge makes the history easier to follow.