### PR TITLE
feat: add SMTP control options (deadline / retry / max-failures / max-MX), rename params for clarity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,35 @@ string + `hasFullInbox` boolean; free-email is a positive signal
 
 ### ✨ Added
 
+#### Configuration presets — `serverless` / `dedicated` / `batch` / `fast`
+
+Pick a sensible default for your deployment shape instead of guessing
+timeouts:
+
+```ts
+import { verifyEmail, VERIFY_EMAIL_PRESETS } from '@emailcheck/email-validator-js';
+
+await verifyEmail({
+  emailAddress: 'alice@example.com',
+  verifySmtp: true,
+  ...VERIFY_EMAIL_PRESETS.serverless,
+});
+```
+
+Four presets covering common workloads:
+
+| Preset | Per-attempt | Total | Max consecutive failures | Max MX | Retry |
+| --- | --- | --- | --- | --- | --- |
+| `serverless` | 2.5 s | **5 s** | 3 | 2 | none |
+| `dedicated` | 5 s | 30 s | unbounded | unbounded | 1 retry, 500 ms exp |
+| `batch` | 10 s | 60 s | unbounded | unbounded | 2 retries, 1 s exp |
+| `fast` | 1.5 s | **3 s** | 2 | **1** | none |
+
+Two parallel exports: `SMTP_PRESETS` (unprefixed field names for
+`verifyMailboxSMTP({ options })`) and `VERIFY_EMAIL_PRESETS` (smtp-prefixed
+field names for `verifyEmail`). Spread + override individual fields as
+needed.
+
 #### `verifyMailboxSMTP` control options
 
 All on `SMTPVerifyOptions` (and re-exported on `VerifyEmailParams`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,220 @@
 # Change Log
 
+## v5.0.0 - 2026-05-02
+
+### 🎯 SMTP probe: full control surface, clearer names, RFC-correct dialogue
+
+The v4 refactor shipped multi-MX iteration, the catch-all dual-probe,
+PIPELINING, enhanced-status surfacing, and operational metrics — all
+hard-coded with no caller-side knobs. v5 adds the missing control
+surface (deadline / retry / max-failures / max-MX), restores STARTTLS
+upgrade (which v4 dropped on a wrong assumption), normalizes the
+reason vocabulary, and renames the ambiguous fields callers had been
+complaining about.
+
+### ⚠️ Breaking changes
+
+#### 1. Renamed `SMTPVerifyOptions` fields for clarity
+
+Old names were unitless or ambiguous about scope. No aliases —
+TypeScript flags every old call site with a `Did you mean…?` hint.
+
+| Before | After | Why |
+| --- | --- | --- |
+| `timeout` | `perAttemptTimeoutMs` | Per-MX×port budget; units in name |
+| `tls` | `tlsConfig` | Matches the `SMTPTLSConfig` type name |
+| `hostname` | `heloHostname` | What it actually is — the EHLO/HELO identity |
+
+#### 2. Renamed `VerifyEmailParams` fields (and `BatchVerifyParams`)
+
+| Before | After | Why |
+| --- | --- | --- |
+| `timeout` | `smtpPerAttemptTimeoutMs` | Scope (SMTP only) + units in name |
+| `whoisTimeout` | `whoisTimeoutMs` | Units in name |
+
+`BatchVerifyParams.timeout` likewise renamed to `smtpPerAttemptTimeoutMs`.
+
+#### 3. SMTP reason vocabulary normalized
+
+`connect_throw:<message>` (synchronous net/tls.connect throws) is gone
+— those now resolve as plain `connection_error`, same key as async
+failures. The diagnostic message is `console.log()`'d via the debug
+logger but no longer baked into the result. One stable value to filter
+on; prefix-matching `startsWith('connect_throw:')` patterns can collapse
+to plain equality checks.
+
+#### 4. Default SMTP sequence includes STARTTLS
+
+The default per-attempt step list went from
+`[greeting, ehlo, mailFrom, rcptTo]` (v4) to
+`[greeting, ehlo, startTls, mailFrom, rcptTo]` (v5). The startTls step
+is conditional — skipped when the port is already TLS (465), when EHLO
+didn't advertise STARTTLS in `'auto'` mode, or when
+`startTls === 'never'` — so existing scripts that don't include
+STARTTLS in their EHLO multi-line continue to work unchanged. Tests
+that DO advertise STARTTLS need to add a `220 ready` line for the
+upgrade response or pass `startTls: 'never'`.
+
+Without this, port 587 submission MXes (Gmail / Outlook / Office 365 /
+ProtonMail / many corporates) reject `MAIL FROM` with
+`530 Must issue STARTTLS first` — v4 had a real-world correctness gap.
+
+#### 5. Dead-weight fields removed from `SmtpVerificationResult`
+
+`success?`, `canConnect?`, `providerUsed?`, `providerSpecific?` —
+declared in the type but never set by the verifier. Removed for a
+cleaner public surface. Provider detection is intentionally
+consumer-side (too domain-specific for a generic library).
+
+#### 6. Dead enum values removed from `VerificationErrorCode`
+
+`mailboxFull` and `freeEmailProvider` were declared but never set or
+read anywhere. `over_quota` is surfaced via the SMTP probe's `error`
+string + `hasFullInbox` boolean; free-email is a positive signal
+(`result.isFree`) and never an error.
+
+### ✨ Added
+
+#### `verifyMailboxSMTP` control options
+
+All on `SMTPVerifyOptions` (and re-exported on `VerifyEmailParams`
+with an `smtp` prefix):
+
+```ts
+await verifyMailboxSMTP({
+  local: 'alice', domain: 'example.com', mxRecords: [...],
+  options: {
+    perAttemptTimeoutMs: 3000,        // bound a single MX × port attempt
+    totalDeadlineMs: 8000,            // bound the entire probe (NEW)
+    maxConsecutiveFailures: 3,        // bail after 3 connection-class failures in a row (NEW)
+    maxMxHosts: 2,                    // try first N MXes only (NEW)
+    retry: {                          // retry connection-class failures (NEW)
+      attempts: 1,
+      delayMs: 200,
+      backoff: 'exponential',         // or 'fixed'
+    },
+  },
+});
+```
+
+For `verifyEmail`, the same knobs are available as
+`smtpTotalDeadlineMs`, `smtpMaxConsecutiveFailures`, `smtpMaxMxHosts`,
+`smtpRetry`. Real-world example — a Yahoo MX-timeout case from a user
+log:
+
+```ts
+await verifyEmail({
+  emailAddress: 'maria.hernandez+news@yahoo.com',
+  verifySmtp: true,
+  smtpTotalDeadlineMs: 5000,         // bail after 5s total
+  smtpMaxConsecutiveFailures: 3,     // OR after 3 timeouts in a row
+});
+// → isDeliverable: false, error: 'connection_timeout' in ~5s
+// instead of 9 attempts × 3s = 27s wall-clock.
+```
+
+#### STARTTLS upgrade (restored from v3)
+
+```ts
+// 'auto' (default) — upgrade if the MX advertises STARTTLS in EHLO.
+// 'never'          — never upgrade; send MAIL FROM in plaintext.
+// 'force'          — send STARTTLS unconditionally; testing only.
+options: { startTls: 'auto' }
+```
+
+After 220, the plaintext socket is wrapped via
+`tls.connect({ socket: plain, ... })` in place. RFC 3207 §4.2 mandates
+re-EHLO after upgrade — pre-TLS state is discarded and capabilities
+are re-read from the post-TLS EHLO. New reasons in the vocabulary:
+`tls_upgrade_failed` (server returned non-220 to STARTTLS) and
+`tls_handshake_failed` (TLS layer errored after 220).
+
+#### `refineReasonByEnhancedStatus` (RFC 3463 helper)
+
+Pure utility that maps RFC 3463 enhanced-status codes to richer reason
+strings. Pure function, no I/O — opt-in refinement, never mutates
+input.
+
+```ts
+import { refineReasonByEnhancedStatus, verifyMailboxSMTP } from '@emailcheck/email-validator-js';
+
+const { smtpResult } = await verifyMailboxSMTP({ ... });
+const refined = refineReasonByEnhancedStatus(smtpResult.error, smtpResult.enhancedStatus);
+// 'mailbox_does_not_exist' instead of 'not_found' when MX returned 550 5.1.1
+```
+
+Mappings: `5.1.1` → `mailbox_does_not_exist`, `5.1.2`/`5.1.3` →
+`bad_destination_*`, `5.1.6` → `mailbox_moved`, `5.2.x` →
+`mailbox_disabled` / `mailbox_full` / `message_too_long` /
+`mailing_list_expansion_problem`, `4.4.x` → `no_answer_from_host` /
+`bad_connection`, `5.7.x` → `delivery_not_authorized` /
+`no_reverse_dns` / `multiple_authentication_failures`. Codes outside
+the table return the input reason unchanged.
+
+#### `result.responseCode` — last SMTP response code
+
+`SmtpVerificationResult.responseCode?: number` carries the most recent
+3-digit SMTP code observed during the probe (e.g. `250`, `550`).
+Removes the need for callers to re-parse `result.transcript` for the
+last code. The type field already existed in v4; v5 actually populates
+it.
+
+#### Public API surface — re-export missing utilities
+
+These were exported from their submodules but weren't reachable from
+the package root (deep imports aren't part of `package.json#exports`):
+
+- `verifyMailboxSMTP` (the direct SMTP probe — primary consumer-facing
+  function)
+- `parseDsn` + `ParsedDsn` (RFC 3463 enhanced-status parser)
+- `parseWhoisData` + `ParsedWhoisResult` (TLD-aware WHOIS parser)
+- `resolveMxRecords` (DNS MX lookup with cache)
+- `defaultDomainSuggestionMethodAsync` (async variant)
+
+`src/index.ts` reorganised with section comments documenting the
+"every `src/*.ts` `export` re-exports through this barrel" rule.
+
+### 🔧 Internal cleanups
+
+- Removed dead `VerificationErrorCode` values (`mailboxFull`,
+  `freeEmailProvider`) and dead `SmtpVerificationResult` fields
+  (`success`, `canConnect`, `providerUsed`, `providerSpecific`).
+- Removed `parseCompositeNamePart`'s `.base` backward-compat field.
+- Cleared the last `noExplicitAny` in `src/`
+  (`CacheStore<T = any>` → `CacheStore<T = unknown>`).
+- Adapter doc-blocks no longer claim "backward compatibility" for
+  legitimate deploy-mode variants (AWS Lambda's
+  `apiGatewayHandler` / `lambdaHandler` / `handler` and Vercel's
+  `edgeHandler` / `nodeHandler` / `handler` are deploy modes, not
+  legacy).
+
+### 📚 Documentation
+
+- **`SMTPVerifyOptions`, `VerifyEmailParams`, `BatchVerifyParams`** —
+  every field has a JSDoc block listing the default value and
+  explaining when each value is the right choice. Fields grouped into
+  sections (Connection envelope / Caching / Time budget + early-stop /
+  Dialogue customization) so the interface reads top-down.
+- README — new "Time-budget controls" section showing the
+  `smtpTotalDeadlineMs` / `smtpMaxConsecutiveFailures` /
+  `smtpMaxMxHosts` / `smtpRetry` recipes.
+- `MIGRATION_email-smtp-probe.md` — updated step-7 (sequence handling
+  now reflects STARTTLS in the default sequence) and step-6 (reason
+  refinement helper now ships in the library).
+
+### Tests
+
+- `__tests__/unit/0117-smtp-control-options.test.ts` — 7 new tests
+  covering every control-option decision path
+- `__tests__/unit/0115-smtp-starttls.test.ts` — 8 new tests for
+  STARTTLS auto / never / force / port 465 no-op / 5xx rejection
+- `__tests__/unit/0116-refine-reason.test.ts` — 23 new tests
+  covering every RFC 3463 mapping + null/undefined handling
+
+Total: **807 unit + 37 isolated + 207 extras = 1051 tests passing.**
+
+---
+
 ## v4.0.0 - 2026-05-01
 
 ### 🚀 Major refactor: Bun-first toolchain, CLI, transcripts, full serverless coverage

--- a/README.md
+++ b/README.md
@@ -818,6 +818,49 @@ console.log(`SMTP result: ${smtpResult.isDeliverable} via port ${port}`);
 console.log(`canConnectSmtp=${smtpResult.canConnectSmtp}, error=${smtpResult.error ?? 'none'}`);
 ```
 
+### Configuration presets (NEW in v5)
+
+Don't want to think about timeouts and retries? Pick a preset that matches your deployment shape:
+
+```typescript
+import { verifyEmail, VERIFY_EMAIL_PRESETS } from '@emailcheck/email-validator-js';
+
+// Lambda / Vercel / Cloudflare-Workers handler
+await verifyEmail({
+  emailAddress: 'alice@example.com',
+  verifySmtp: true,
+  ...VERIFY_EMAIL_PRESETS.serverless,
+});
+
+// Long-running worker / dyno
+await verifyEmail({ ..., ...VERIFY_EMAIL_PRESETS.dedicated });
+
+// Bulk processing
+await verifyEmail({ ..., ...VERIFY_EMAIL_PRESETS.batch });
+
+// Form-autocomplete UX (sub-3s)
+await verifyEmail({ ..., ...VERIFY_EMAIL_PRESETS.fast });
+```
+
+| Preset | Per-attempt | Total deadline | Max consecutive failures | Max MX | Retry |
+| --- | --- | --- | --- | --- | --- |
+| `serverless` | 2500 ms | **5 s** | 3 | 2 | none — fail fast |
+| `dedicated` | 5000 ms | 30 s | unbounded | unbounded | 1 retry, 500 ms exp backoff |
+| `batch` | 10 000 ms | 60 s | unbounded | unbounded | 2 retries, 1 s exp backoff |
+| `fast` | 1500 ms | **3 s** | 2 | **1** | none — fail fast |
+
+`SMTP_PRESETS` is a parallel set with the unprefixed field names for `verifyMailboxSMTP({ options })` callers — same values, same shape.
+
+You can spread + override:
+
+```typescript
+await verifyEmail({
+  emailAddress: 'alice@example.com',
+  ...VERIFY_EMAIL_PRESETS.serverless,
+  smtpTotalDeadlineMs: 3000, // tighter than the preset's 5s
+});
+```
+
 ### Time-budget controls (NEW in v5)
 
 The probe walks `mxRecords × ports` (worst-case 4 × 3 = 12 attempts at 3s each = 36s). Four orthogonal knobs let you bound that:

--- a/README.md
+++ b/README.md
@@ -113,7 +113,8 @@ const result = await verifyEmail({
   emailAddress: 'user@mydomain.com',
   verifyMx: true,
   verifySmtp: true,
-  timeout: 3000
+  smtpPerAttemptTimeoutMs: 3000,    // bounds a single MX × port attempt
+  smtpTotalDeadlineMs: 8000,        // bounds the entire SMTP probe (NEW in v5)
 });
 
 console.log(result.validFormat);  // true
@@ -249,25 +250,31 @@ If you're using an IDE with refactoring support (like VS Code), you can use find
 Comprehensive email verification with detailed results and error codes.
 
 **Parameters:**
-- `emailAddress` (string, required): Email address to verify
-- `timeout` (number): Timeout in milliseconds (default: 4000)
-- `verifyMx` (boolean): Check MX records (default: true)
-- `verifySmtp` (boolean): Verify SMTP connection (default: false)
-- `smtpPort` (number): Custom SMTP port
-- `debug` (boolean): Enable debug logging (default: false)
-- `checkDisposable` (boolean): Check for disposable emails (default: true)
-- `checkFree` (boolean): Check for free email providers (default: true)
-- `retryAttempts` (number): Retry attempts for failures (default: 1)
-- `detectName` (boolean): Detect names from email address (default: false)
-- `nameDetectionMethod` (function): Custom name detection method
-- `suggestDomain` (boolean): Enable domain typo suggestions (default: true)
-- `domainSuggestionMethod` (function): Custom domain suggestion method
-- `commonDomains` (string[]): Custom list of domains for suggestions
-- `checkDomainAge` (boolean): Check domain age (default: false)
-- `checkDomainRegistration` (boolean): Check domain registration status (default: false)
-- `whoisTimeout` (number): WHOIS lookup timeout (default: 5000)
-- `debug` (boolean): Enable debug logging including WHOIS lookups (default: false)
-- `cache` (ICache): Optional custom cache instance
+- `emailAddress` (string, required) — Email address to verify.
+- `verifyMx` (boolean) — Resolve MX records (default: `true`).
+- `verifySmtp` (boolean) — Run live SMTP probe (default: `false`).
+- `checkDisposable` (boolean) — Disposable-provider list check (default: `true`).
+- `checkFree` (boolean) — Free-provider list check (default: `true`).
+- `detectName` (boolean) — Extract first/last name from local-part (default: `false`).
+- `suggestDomain` (boolean) — Suggest a corrected domain on typos (default: `true`).
+- `checkDomainAge` (boolean) — WHOIS creation-date lookup (default: `false`).
+- `checkDomainRegistration` (boolean) — WHOIS registration / expiry / lock lookup (default: `false`).
+- `skipMxForDisposable` (boolean) — Skip MX/SMTP for disposable addresses (default: `false`).
+- `skipDomainWhoisForDisposable` (boolean) — Skip WHOIS for disposable addresses (default: `false`).
+- `smtpPort` (number) — Force a specific port for the SMTP probe (overrides the `[25, 587, 465]` walk).
+- **SMTP time-budget controls** (NEW in v5):
+  - `smtpPerAttemptTimeoutMs` (number) — Per-MX × port budget in ms (default: `4000`).
+  - `smtpTotalDeadlineMs` (number) — Hard cap on total wall-clock for the SMTP probe. Use this from a request handler with a tight latency budget. Default: unbounded.
+  - `smtpMaxConsecutiveFailures` (number) — Bail after N connection-class failures in a row (`connection_error` / `connection_timeout` / `connection_closed`). Default: unbounded.
+  - `smtpMaxMxHosts` (number) — Cap the MX walk to the first N hostnames. Default: unbounded.
+  - `smtpRetry` (`{ attempts, delayMs?, backoff? }`) — Retry connection-class failures on the same MX × port. Default: no retries.
+- `whoisTimeoutMs` (number) — Per-WHOIS-query timeout (default: `5000`).
+- `debug` (boolean) — Per-line `console.debug` trace (default: `false`).
+- `captureTranscript` (boolean) — Populate `result.transcript` with a per-step structured trace (default: `false`).
+- `nameDetectionMethod` (function) — Override the default name-detection heuristic.
+- `domainSuggestionMethod` (function) — Override the default typo-suggestion heuristic.
+- `commonDomains` (string[]) — Custom canonical-domain list for the typo suggester.
+- `cache` (Cache) — Optional shared cache (MX, WHOIS, disposable / free, SMTP, domain results all stored).
 
 **Returns:**
 ```typescript
@@ -736,7 +743,7 @@ const result = await verifyEmail({
   emailAddress: 'foo@email.com',
   verifyMx: true,
   verifySmtp: true,
-  timeout: 3000
+  smtpPerAttemptTimeoutMs: 3000,
 });
 console.log(result.validFormat);  // true
 console.log(result.validMx);      // true
@@ -790,22 +797,70 @@ const { smtpResult, port, cached, portCached } = await verifyMailboxSMTP({
   domain: 'example.com',
   mxRecords: ['mx.example.com'],
   options: {
-    ports: [25, 587, 465],   // Plain → STARTTLS-able → implicit-TLS
-    timeout: 5000,
-    cache: getDefaultCache(), // Per-isolate verdict + port cache
+    ports: [25, 587, 465],         // Plain → STARTTLS-able → implicit-TLS
+    perAttemptTimeoutMs: 5000,     // Per-MX × port budget (renamed from `timeout` in v5)
+    totalDeadlineMs: 12_000,       // Hard cap on total wall-clock (NEW in v5)
+    maxConsecutiveFailures: 3,     // Bail after N connection-class failures (NEW in v5)
+    cache: getDefaultCache(),      // Per-isolate verdict + port cache
     debug: false,
-    tls: {
+    tlsConfig: {                   // Renamed from `tls` in v5
       rejectUnauthorized: false,
       minVersion: 'TLSv1.2',
     },
-    hostname: 'your-domain.com',  // EHLO/HELO identity
-    captureTranscript: false,     // see "SMTP Transcript Capture" below
+    heloHostname: 'your-domain.com', // EHLO/HELO identity (renamed from `hostname` in v5)
+    startTls: 'auto',              // STARTTLS upgrade on plaintext ports (NEW in v5)
+    pipelining: 'auto',            // Use SMTP PIPELINING when advertised
+    captureTranscript: false,      // See "SMTP Transcript Capture" below
   },
 });
 
 console.log(`SMTP result: ${smtpResult.isDeliverable} via port ${port}`);
 console.log(`canConnectSmtp=${smtpResult.canConnectSmtp}, error=${smtpResult.error ?? 'none'}`);
 ```
+
+### Time-budget controls (NEW in v5)
+
+The probe walks `mxRecords × ports` (worst-case 4 × 3 = 12 attempts at 3s each = 36s). Four orthogonal knobs let you bound that:
+
+```typescript
+import { verifyEmail, verifyMailboxSMTP } from '@emailcheck/email-validator-js';
+
+await verifyEmail({
+  emailAddress: 'maria.hernandez+news@yahoo.com',
+  verifySmtp: true,
+  smtpPerAttemptTimeoutMs: 3000,    // Bound a single MX × port attempt
+  smtpTotalDeadlineMs: 5000,        // Hard cap on total wall-clock
+  smtpMaxConsecutiveFailures: 3,    // Bail after 3 connection failures in a row
+  smtpMaxMxHosts: 2,                // Try only the first 2 MXes
+  smtpRetry: {                      // Retry connection-class failures
+    attempts: 1,
+    delayMs: 200,
+    backoff: 'exponential',         // or 'fixed'
+  },
+});
+
+// On verifyMailboxSMTP directly, the same knobs are unprefixed:
+await verifyMailboxSMTP({
+  local: 'alice', domain: 'example.com', mxRecords: [...],
+  options: {
+    perAttemptTimeoutMs: 3000,
+    totalDeadlineMs: 5000,
+    maxConsecutiveFailures: 3,
+    maxMxHosts: 2,
+    retry: { attempts: 1, delayMs: 200, backoff: 'exponential' },
+  },
+});
+```
+
+| Knob | Default | When to use |
+| --- | --- | --- |
+| `(smtp)PerAttemptTimeoutMs` | `4000` (verifyEmail) / `3000` (verifyMailboxSMTP) | Per-MX × port budget. Bound a single attempt. |
+| `(smtp)TotalDeadlineMs` | unbounded | Hard wall-clock cap. Use from a request handler with a tight latency budget. |
+| `(smtp)MaxConsecutiveFailures` | unbounded | Cut off probes when the network path is dead. Counter resets on any non-connection-class outcome. |
+| `(smtp)MaxMxHosts` | unbounded | Cap the MX walk regardless of how many DNS returned. |
+| `(smtp)Retry` | no retries | Retry connection-class failures on the same MX × port. Definitive answers (250 / 550 / 552) are never retried. |
+
+`PerAttemptTimeout` and `TotalDeadline` are **orthogonal** — use both when you have both a per-attempt SLO and a hard caller-side budget.
 
 ### Custom SMTP step sequence
 
@@ -839,11 +894,11 @@ const { smtpResult } = await verifyMailboxSMTP({
   local: 'user',
   domain: 'example.com',
   mxRecords: ['mx.example.com'],
-  options: { ports: [25, 587], timeout: 5000, captureTranscript: true },
+  options: { ports: [25, 587], perAttemptTimeoutMs: 5000, captureTranscript: true },
 });
 
-// Both arrays aggregate across every port attempted, prefixed with the port:
-//   "25|s| 220 mx.example.com ESMTP"
+// Both arrays aggregate across every MX × port attempted, prefixed:
+//   "mx.example.com:25|s| 220 mx.example.com ESMTP"
 //   "25|c| EHLO localhost"
 console.log(smtpResult.transcript);
 console.log(smtpResult.commands);

--- a/__tests__/integration/0100-smtp-basic.test.ts
+++ b/__tests__/integration/0100-smtp-basic.test.ts
@@ -117,7 +117,7 @@ describe('0100 SMTP Basic', () => {
           options: {
             debug: true,
             ports: [587],
-            timeout: 3000,
+            perAttemptTimeoutMs: 3000,
           },
         });
 
@@ -139,7 +139,7 @@ describe('0100 SMTP Basic', () => {
           options: {
             debug: false,
             ports: [587],
-            timeout: 3000,
+            perAttemptTimeoutMs: 3000,
           },
         });
 
@@ -160,7 +160,7 @@ describe('0100 SMTP Basic', () => {
       async () => {
         const params = createTestParams({
           options: {
-            hostname: 'custom-test.example.com',
+            heloHostname: 'custom-test.example.com',
             ports: [587],
           },
         });
@@ -176,7 +176,7 @@ describe('0100 SMTP Basic', () => {
       async () => {
         const params = createTestParams({
           options: {
-            hostname: 'localhost',
+            heloHostname: 'localhost',
             ports: [587],
           },
         });
@@ -269,7 +269,7 @@ describe('0100 SMTP Basic', () => {
             mxRecords: mx,
             options: {
               ports: [587],
-              timeout: 5000,
+              perAttemptTimeoutMs: 5000,
             },
           });
 

--- a/__tests__/integration/0101-smtp-ports.test.ts
+++ b/__tests__/integration/0101-smtp-ports.test.ts
@@ -69,7 +69,7 @@ describe('0101 SMTP Ports', () => {
       const params = createTestParams({
         options: {
           ports: [9999], // Invalid port
-          timeout: 2000,
+          perAttemptTimeoutMs: 2000,
         },
       });
 
@@ -81,7 +81,7 @@ describe('0101 SMTP Ports', () => {
       const params = createTestParams({
         options: {
           ports: [80, 443], // HTTP/HTTPS ports (not SMTP)
-          timeout: 2000,
+          perAttemptTimeoutMs: 2000,
         },
       });
 
@@ -113,7 +113,7 @@ describe('0101 SMTP Ports', () => {
         const params = createTestParams({
           options: {
             ports: [25, 587, 465],
-            timeout: 3000,
+            perAttemptTimeoutMs: 3000,
           },
         });
 
@@ -132,7 +132,7 @@ describe('0101 SMTP Ports', () => {
         const params = createTestParams({
           options: {
             ports: [465, 587, 25], // Reverse order
-            timeout: 3000,
+            perAttemptTimeoutMs: 3000,
           },
         });
 
@@ -148,7 +148,7 @@ describe('0101 SMTP Ports', () => {
         const params = createTestParams({
           options: {
             ports: [587, 587, 465, 465], // Duplicates
-            timeout: 3000,
+            perAttemptTimeoutMs: 3000,
           },
         });
 
@@ -166,7 +166,7 @@ describe('0101 SMTP Ports', () => {
         const params = createTestParams({
           options: {
             ports: [25],
-            tls: true,
+            tlsConfig: true,
             debug: true, // Enable to see TLS upgrade
           },
         });
@@ -183,7 +183,7 @@ describe('0101 SMTP Ports', () => {
         const params = createTestParams({
           options: {
             ports: [587],
-            tls: true,
+            tlsConfig: true,
           },
         });
 
@@ -199,7 +199,7 @@ describe('0101 SMTP Ports', () => {
         const params = createTestParams({
           options: {
             ports: [465],
-            tls: true,
+            tlsConfig: true,
           },
         });
 
@@ -215,7 +215,7 @@ describe('0101 SMTP Ports', () => {
         const params = createTestParams({
           options: {
             ports: [25],
-            tls: false,
+            tlsConfig: false,
           },
         });
 
@@ -233,7 +233,7 @@ describe('0101 SMTP Ports', () => {
         const params = createTestParams({
           options: {
             ports: [587], // Start with most likely to work
-            timeout: 2000,
+            perAttemptTimeoutMs: 2000,
           },
         });
 
@@ -255,7 +255,7 @@ describe('0101 SMTP Ports', () => {
         const params = createTestParams({
           options: {
             ports: [25],
-            timeout: 1000, // Short timeout to trigger retries
+            perAttemptTimeoutMs: 1000, // Short timeout to trigger retries
             debug: false,
           },
         });
@@ -270,7 +270,7 @@ describe('0101 SMTP Ports', () => {
       const params = createTestParams({
         options: {
           ports: [9999], // Closed port → immediate connection_error or short timeout
-          timeout: 1000,
+          perAttemptTimeoutMs: 1000,
         },
       });
 
@@ -303,7 +303,7 @@ describe('0101 SMTP Ports', () => {
             mxRecords: domain.mx,
             options: {
               ports: [domain.preferredPort],
-              timeout: 5000,
+              perAttemptTimeoutMs: 5000,
             },
           });
 
@@ -331,7 +331,7 @@ describe('0101 SMTP Ports', () => {
       const params = createTestParams({
         options: {
           ports: [0],
-          timeout: 1000,
+          perAttemptTimeoutMs: 1000,
         },
       });
 
@@ -343,7 +343,7 @@ describe('0101 SMTP Ports', () => {
       const params = createTestParams({
         options: {
           ports: [-1, 25],
-          timeout: 1000,
+          perAttemptTimeoutMs: 1000,
         },
       });
 
@@ -355,7 +355,7 @@ describe('0101 SMTP Ports', () => {
       const params = createTestParams({
         options: {
           ports: [65535],
-          timeout: 1000,
+          perAttemptTimeoutMs: 1000,
         },
       });
 

--- a/__tests__/integration/0102-smtp-tls.test.ts
+++ b/__tests__/integration/0102-smtp-tls.test.ts
@@ -23,7 +23,7 @@ describe('0102 SMTP TLS', () => {
         const params = createTestParams({
           options: {
             ports: [587, 465],
-            tls: true,
+            tlsConfig: true,
           },
         });
 
@@ -52,7 +52,7 @@ describe('0102 SMTP TLS', () => {
         const params = createTestParams({
           options: {
             ports: [25],
-            tls: true,
+            tlsConfig: true,
           },
         });
 
@@ -68,7 +68,7 @@ describe('0102 SMTP TLS', () => {
         const params = createTestParams({
           options: {
             ports: [587],
-            tls: true,
+            tlsConfig: true,
           },
         });
 
@@ -84,7 +84,7 @@ describe('0102 SMTP TLS', () => {
         const params = createTestParams({
           options: {
             ports: [465],
-            tls: true,
+            tlsConfig: true,
           },
         });
 
@@ -102,7 +102,7 @@ describe('0102 SMTP TLS', () => {
         const params = createTestParams({
           options: {
             ports: [587],
-            tls: {
+            tlsConfig: {
               rejectUnauthorized: false,
             },
           },
@@ -120,7 +120,7 @@ describe('0102 SMTP TLS', () => {
         const params = createTestParams({
           options: {
             ports: [465], // More likely to have valid certs
-            tls: {
+            tlsConfig: {
               rejectUnauthorized: true,
             },
           },
@@ -138,7 +138,7 @@ describe('0102 SMTP TLS', () => {
         const params = createTestParams({
           options: {
             ports: [587],
-            tls: {
+            tlsConfig: {
               rejectUnauthorized: true,
             },
           },
@@ -159,7 +159,7 @@ describe('0102 SMTP TLS', () => {
         const params = createTestParams({
           options: {
             ports: [587],
-            tls: {
+            tlsConfig: {
               minVersion: 'TLSv1.2',
             },
           },
@@ -177,7 +177,7 @@ describe('0102 SMTP TLS', () => {
         const params = createTestParams({
           options: {
             ports: [465], // More likely to support TLS 1.3
-            tls: {
+            tlsConfig: {
               minVersion: 'TLSv1.3',
             },
           },
@@ -195,7 +195,7 @@ describe('0102 SMTP TLS', () => {
         const params = createTestParams({
           options: {
             ports: [587],
-            tls: {
+            tlsConfig: {
               minVersion: 'TLSv1.2', // Most servers support this
             },
           },
@@ -241,7 +241,7 @@ describe('0102 SMTP TLS', () => {
         const params = createTestParams({
           options: {
             ports: [587],
-            tls: {
+            tlsConfig: {
               rejectUnauthorized: false,
               minVersion: 'TLSv1.2',
             },
@@ -264,7 +264,7 @@ describe('0102 SMTP TLS', () => {
         const params = createTestParams({
           options: {
             ports: [25],
-            tls: true,
+            tlsConfig: true,
             debug: true,
           },
         });
@@ -288,7 +288,7 @@ describe('0102 SMTP TLS', () => {
         const params = createTestParams({
           options: {
             ports: [587],
-            tls: true,
+            tlsConfig: true,
           },
         });
 
@@ -304,7 +304,7 @@ describe('0102 SMTP TLS', () => {
         const params = createTestParams({
           options: {
             ports: [465],
-            tls: true,
+            tlsConfig: true,
           },
         });
 
@@ -320,7 +320,7 @@ describe('0102 SMTP TLS', () => {
         const params = createTestParams({
           options: {
             ports: [25],
-            tls: true,
+            tlsConfig: true,
           },
         });
 
@@ -336,10 +336,10 @@ describe('0102 SMTP TLS', () => {
       'should compare TLS vs non-TLS performance',
       async () => {
         const testCases = [
-          { name: 'No TLS', tls: false, port: 25 },
-          { name: 'TLS Port 25', tls: true, port: 25 },
-          { name: 'TLS Port 587', tls: true, port: 587 },
-          { name: 'TLS Port 465', tls: true, port: 465 },
+          { name: 'No TLS', tlsConfig: false, port: 25 },
+          { name: 'TLS Port 25', tlsConfig: true, port: 25 },
+          { name: 'TLS Port 587', tlsConfig: true, port: 587 },
+          { name: 'TLS Port 465', tlsConfig: true, port: 465 },
         ];
 
         const results: { [key: string]: { result: boolean | null; duration: number } } = {};
@@ -348,7 +348,7 @@ describe('0102 SMTP TLS', () => {
           const params = createTestParams({
             options: {
               ports: [testCase.port],
-              tls: testCase.tls,
+              tlsConfig: testCase.tlsConfig,
               debug: false,
             },
           });
@@ -374,10 +374,10 @@ describe('0102 SMTP TLS', () => {
         const params = createTestParams({
           options: {
             ports: [465],
-            tls: {
+            tlsConfig: {
               rejectUnauthorized: true,
             },
-            timeout: 1000, // Short timeout for TLS handshake
+            perAttemptTimeoutMs: 1000, // Short timeout for TLS handshake
           },
         });
 
@@ -395,7 +395,7 @@ describe('0102 SMTP TLS', () => {
         const params = createTestParams({
           options: {
             ports: [465, 587, 25], // Secure ports first
-            tls: true,
+            tlsConfig: true,
           },
         });
 
@@ -411,7 +411,7 @@ describe('0102 SMTP TLS', () => {
         const params = createTestParams({
           options: {
             ports: [25, 587, 465], // Mixed order
-            tls: true,
+            tlsConfig: true,
           },
         });
 
@@ -427,7 +427,7 @@ describe('0102 SMTP TLS', () => {
         const params = createTestParams({
           options: {
             ports: [25],
-            tls: true,
+            tlsConfig: true,
           },
         });
 
@@ -446,7 +446,7 @@ describe('0102 SMTP TLS', () => {
         const params = createTestParams({
           options: {
             ports: [587],
-            tls: true,
+            tlsConfig: true,
             sequence: {
               steps: ['GREETING', 'EHLO', 'STARTTLS', 'MAIL_FROM', 'RCPT_TO'] as any,
             },
@@ -465,7 +465,7 @@ describe('0102 SMTP TLS', () => {
         const params = createTestParams({
           options: {
             ports: [587],
-            tls: true,
+            tlsConfig: true,
             sequence: {
               steps: ['GREETING', 'EHLO', 'MAIL_FROM', 'RCPT_TO'] as any, // No STARTTLS
             },

--- a/__tests__/integration/0104-smtp-errors.test.ts
+++ b/__tests__/integration/0104-smtp-errors.test.ts
@@ -22,7 +22,7 @@ describe('0104 SMTP Errors', () => {
       const params = createTestParams({
         mxRecords: ['invalid.nonexistent.server.test'],
         options: {
-          timeout: 2000,
+          perAttemptTimeoutMs: 2000,
         },
       });
 
@@ -34,7 +34,7 @@ describe('0104 SMTP Errors', () => {
       const params = createTestParams({
         mxRecords: ['timeout.test.invalid'], // Use a hostname that will timeout
         options: {
-          timeout: 1000,
+          perAttemptTimeoutMs: 1000,
         },
       });
 
@@ -47,7 +47,7 @@ describe('0104 SMTP Errors', () => {
         mxRecords: ['localhost'],
         options: {
           ports: [25], // No SMTP server typically running on localhost
-          timeout: 2000,
+          perAttemptTimeoutMs: 2000,
         },
       });
 
@@ -60,7 +60,7 @@ describe('0104 SMTP Errors', () => {
       const params = createTestParams({
         mxRecords: [''].filter(Boolean), // Results in empty array
         options: {
-          timeout: 2000,
+          perAttemptTimeoutMs: 2000,
         },
       });
 
@@ -117,7 +117,7 @@ describe('0104 SMTP Errors', () => {
         domain: longDomain,
         mxRecords: ['mx.example.com'],
         options: {
-          timeout: 5000,
+          perAttemptTimeoutMs: 5000,
         },
       });
 
@@ -153,7 +153,7 @@ describe('0104 SMTP Errors', () => {
     it('should handle very short timeout', async () => {
       const params = createTestParams({
         options: {
-          timeout: 1, // 1ms timeout
+          perAttemptTimeoutMs: 1, // 1ms timeout
         },
       });
 
@@ -165,7 +165,7 @@ describe('0104 SMTP Errors', () => {
       const params = createTestParams({
         mxRecords: ['timeout2.test.invalid'], // Use hostname that will timeout
         options: {
-          timeout: 2000,
+          perAttemptTimeoutMs: 2000,
         },
       });
 
@@ -180,7 +180,7 @@ describe('0104 SMTP Errors', () => {
       const params = createTestParams({
         mxRecords: ['timeout3.test.invalid'],
         options: {
-          timeout: 1000,
+          perAttemptTimeoutMs: 1000,
         },
       });
 
@@ -201,7 +201,7 @@ describe('0104 SMTP Errors', () => {
         const params = createTestParams({
           options: {
             ports: [port],
-            timeout: 1000,
+            perAttemptTimeoutMs: 1000,
           },
         });
 
@@ -217,7 +217,7 @@ describe('0104 SMTP Errors', () => {
         const params = createTestParams({
           options: {
             ports: [port],
-            timeout: 1000, // Short timeout to avoid hanging
+            perAttemptTimeoutMs: 1000, // Short timeout to avoid hanging
           },
         });
 
@@ -244,7 +244,7 @@ describe('0104 SMTP Errors', () => {
       const params = createTestParams({
         options: {
           ports: [587],
-          tls: {
+          tlsConfig: {
             rejectUnauthorized: true,
             // Use a server with invalid cert if available
           },
@@ -260,7 +260,7 @@ describe('0104 SMTP Errors', () => {
       const params = createTestParams({
         options: {
           ports: [587],
-          tls: {
+          tlsConfig: {
             minVersion: 'TLSv1.3', // Not all servers support
           },
         },
@@ -282,7 +282,7 @@ describe('0104 SMTP Errors', () => {
             steps: [],
           },
           ports: [587],
-          timeout: 1500,
+          perAttemptTimeoutMs: 1500,
         },
       });
 
@@ -314,7 +314,7 @@ describe('0104 SMTP Errors', () => {
           mxRecords: ['gmail-smtp-in.l.google.com'],
           options: {
             ports: [587],
-            timeout: 5000,
+            perAttemptTimeoutMs: 5000,
             cache: getDefaultCache(),
             debug: false,
           },
@@ -333,7 +333,7 @@ describe('0104 SMTP Errors', () => {
           local: `rapid${i}`,
           options: {
             ports: [587],
-            timeout: 3000,
+            perAttemptTimeoutMs: 3000,
             cache: getDefaultCache(),
           },
         });
@@ -349,7 +349,7 @@ describe('0104 SMTP Errors', () => {
       const params = createTestParams({
         options: {
           ports: [9999, 587], // First will fail, second might work
-          timeout: 2000,
+          perAttemptTimeoutMs: 2000,
         },
       });
 
@@ -364,7 +364,7 @@ describe('0104 SMTP Errors', () => {
           sequence: {
             steps: [SMTPStep.greeting, SMTPStep.ehlo],
           },
-          timeout: 3000,
+          perAttemptTimeoutMs: 3000,
         },
       });
 
@@ -377,7 +377,7 @@ describe('0104 SMTP Errors', () => {
         mxRecords: ['localhost'], // Might close connection
         options: {
           ports: [25],
-          timeout: 2000,
+          perAttemptTimeoutMs: 2000,
         },
       });
 
@@ -391,7 +391,7 @@ describe('0104 SMTP Errors', () => {
       const params = createTestParams({
         mxRecords: ['invalid.test'],
         options: {
-          timeout: 100,
+          perAttemptTimeoutMs: 100,
         },
       });
 
@@ -409,7 +409,7 @@ describe('0104 SMTP Errors', () => {
       const params = createTestParams({
         options: {
           ports: [587],
-          timeout: 2000,
+          perAttemptTimeoutMs: 2000,
         },
       });
 

--- a/__tests__/unit/0006-detailed-verification.test.ts
+++ b/__tests__/unit/0006-detailed-verification.test.ts
@@ -67,7 +67,7 @@ describe('0006 Detailed Email Verification', () => {
         verifyMx: true,
         verifySmtp: true,
         debug: true,
-        timeout: 1000,
+        smtpPerAttemptTimeoutMs: 1000,
       });
 
       // 550 = mailbox not found → SMTP responded, recipient invalid.
@@ -82,7 +82,7 @@ describe('0006 Detailed Email Verification', () => {
         emailAddress: 'test@example.com',
         verifyMx: true,
         verifySmtp: true,
-        timeout: 500,
+        smtpPerAttemptTimeoutMs: 500,
       });
       expect(result.validSmtp).toBe(null);
     });
@@ -105,7 +105,7 @@ describe('0006 Detailed Email Verification', () => {
         verifyMx: true,
         verifySmtp: true,
         cache: sharedCache,
-        timeout: 2000,
+        smtpPerAttemptTimeoutMs: 2000,
       });
       expect(result1.metadata?.cached).toBe(false);
 
@@ -114,7 +114,7 @@ describe('0006 Detailed Email Verification', () => {
         verifyMx: true,
         verifySmtp: true,
         cache: sharedCache,
-        timeout: 2000,
+        smtpPerAttemptTimeoutMs: 2000,
       });
       expect(result2.metadata?.cached).toBe(true);
     });

--- a/__tests__/unit/0009-verify-email-transcript.test.ts
+++ b/__tests__/unit/0009-verify-email-transcript.test.ts
@@ -137,7 +137,7 @@ describe('0009 verifyEmail transcript', () => {
       emailAddress: 'alice@example.com',
       verifyMx: true,
       verifySmtp: true,
-      timeout: 1000,
+      smtpPerAttemptTimeoutMs: 1000,
       captureTranscript: true,
     });
     const smtp = step(result.transcript, 'smtp-probe');
@@ -161,14 +161,14 @@ describe('0009 verifyEmail transcript', () => {
       emailAddress: 'alice@example.com',
       verifyMx: true,
       verifySmtp: true,
-      timeout: 1000,
+      smtpPerAttemptTimeoutMs: 1000,
     });
     // Second call — should hit the SMTP cache.
     const result = await verifyEmail({
       emailAddress: 'alice@example.com',
       verifyMx: true,
       verifySmtp: true,
-      timeout: 1000,
+      smtpPerAttemptTimeoutMs: 1000,
       captureTranscript: true,
     });
     const smtp = step(result.transcript, 'smtp-probe');
@@ -211,7 +211,7 @@ describe('0009 verifyEmail transcript', () => {
       emailAddress: 'alice@example.com',
       verifyMx: false,
       checkDomainAge: true,
-      whoisTimeout: 2000,
+      whoisTimeoutMs: 2000,
       captureTranscript: true,
     });
     const age = step(result.transcript, 'whois-age');

--- a/__tests__/unit/0107-socket-mock.test.ts
+++ b/__tests__/unit/0107-socket-mock.test.ts
@@ -49,7 +49,7 @@ describe('0107 Socket Mock', () => {
         verifyMx: true,
         verifySmtp: true,
         debug: true,
-        timeout: 1000,
+        smtpPerAttemptTimeoutMs: 1000,
       });
       expect(fakeNet.mxCalls.length).toBeGreaterThan(0);
       expect(result.validFormat).toBe(true);
@@ -74,7 +74,7 @@ describe('0107 Socket Mock', () => {
           verifySmtp: true,
           verifyMx: true,
           debug: true,
-          timeout: 1000,
+          smtpPerAttemptTimeoutMs: 1000,
         });
         expect(result.validSmtp).toBe(true);
       });
@@ -86,7 +86,7 @@ describe('0107 Socket Mock', () => {
           verifySmtp: true,
           verifyMx: true,
           debug: true,
-          timeout: 1000,
+          smtpPerAttemptTimeoutMs: 1000,
         });
         expect(result.validSmtp).toBe(true);
       });
@@ -103,7 +103,7 @@ describe('0107 Socket Mock', () => {
           verifySmtp: true,
           verifyMx: true,
           debug: true,
-          timeout: 1000,
+          smtpPerAttemptTimeoutMs: 1000,
         });
         expect(result.validSmtp).toBe(false);
         expect(result.validFormat).toBe(true);
@@ -122,7 +122,7 @@ describe('0107 Socket Mock', () => {
           verifySmtp: true,
           verifyMx: true,
           debug: true,
-          timeout: 1000,
+          smtpPerAttemptTimeoutMs: 1000,
         });
         expect(result.validSmtp).toBe(true);
       });
@@ -139,7 +139,7 @@ describe('0107 Socket Mock', () => {
           verifySmtp: true,
           verifyMx: true,
           debug: true,
-          timeout: 1000,
+          smtpPerAttemptTimeoutMs: 1000,
         });
         expect(result.validSmtp).toBe(true);
       });
@@ -151,7 +151,7 @@ describe('0107 Socket Mock', () => {
           verifySmtp: true,
           verifyMx: true,
           debug: true,
-          timeout: 500,
+          smtpPerAttemptTimeoutMs: 500,
         });
         expect(result.validSmtp).toBe(null);
         expect(result.validMx).toBe(true);
@@ -172,7 +172,7 @@ describe('0107 Socket Mock', () => {
           emailAddress: 'bar@foo.com',
           verifySmtp: true,
           verifyMx: true,
-          timeout: 1000,
+          smtpPerAttemptTimeoutMs: 1000,
         });
         expect(result.validSmtp).toBe(true);
       });
@@ -183,7 +183,7 @@ describe('0107 Socket Mock', () => {
           emailAddress: 'bar@foo.com',
           verifySmtp: true,
           verifyMx: true,
-          timeout: 1000,
+          smtpPerAttemptTimeoutMs: 1000,
         });
         expect(result.validSmtp).toBe(null);
       });
@@ -194,7 +194,7 @@ describe('0107 Socket Mock', () => {
           emailAddress: 'bar@foo.com',
           verifySmtp: true,
           verifyMx: true,
-          timeout: 1000,
+          smtpPerAttemptTimeoutMs: 1000,
         });
         expect(result.validSmtp).toBe(false);
       });
@@ -210,7 +210,7 @@ describe('0107 Socket Mock', () => {
           emailAddress: 'bar@foo.com',
           verifySmtp: true,
           verifyMx: true,
-          timeout: 1000,
+          smtpPerAttemptTimeoutMs: 1000,
         });
         expect(result.validSmtp).toBe(null);
       });
@@ -226,7 +226,7 @@ describe('0107 Socket Mock', () => {
           emailAddress: 'bar@foo.com',
           verifySmtp: true,
           verifyMx: true,
-          timeout: 1000,
+          smtpPerAttemptTimeoutMs: 1000,
         });
         expect(result.validSmtp).toBe(null);
       });

--- a/__tests__/unit/0110-smtp-verifier.unit.test.ts
+++ b/__tests__/unit/0110-smtp-verifier.unit.test.ts
@@ -46,7 +46,7 @@ describe('0110 SMTP Verifier Unit', () => {
       local: 'john',
       domain: 'example.com',
       mxRecords: ['mx.example.com'],
-      options: { timeout: 200, ports: [25] },
+      options: { perAttemptTimeoutMs: 200, ports: [25] },
     });
 
     expect(port).toBe(25);
@@ -59,7 +59,7 @@ describe('0110 SMTP Verifier Unit', () => {
       local: 'john',
       domain: 'example.com',
       mxRecords: [],
-      options: { timeout: 50 },
+      options: { perAttemptTimeoutMs: 50 },
     });
 
     expect(port).toBe(0);
@@ -74,7 +74,7 @@ describe('0110 SMTP Verifier Unit', () => {
       local: 'missing',
       domain: 'example.com',
       mxRecords: ['mx.example.com'],
-      options: { timeout: 200, ports: [587] },
+      options: { perAttemptTimeoutMs: 200, ports: [587] },
     });
 
     expect(smtpResult.isDeliverable).toBe(false);
@@ -93,7 +93,7 @@ describe('0110 SMTP Verifier Unit', () => {
       local: 'john',
       domain: 'example.com',
       mxRecords: ['mx.example.com'],
-      options: { timeout: 200, ports: [587] },
+      options: { perAttemptTimeoutMs: 200, ports: [587] },
     });
 
     expect(smtpResult.isDeliverable).toBe(true);
@@ -107,7 +107,7 @@ describe('0110 SMTP Verifier Unit', () => {
       local: 'john',
       domain: 'example.com',
       mxRecords: ['mx.example.com'],
-      options: { ports: [25, 587], timeout: 100 },
+      options: { ports: [25, 587], perAttemptTimeoutMs: 100 },
     });
 
     expect(port).toBe(587);
@@ -124,7 +124,7 @@ describe('0110 SMTP Verifier Unit', () => {
       local: 'first',
       domain: 'example.com',
       mxRecords: ['mx.example.com'],
-      options: { ports: [25, 587], timeout: 200, cache },
+      options: { ports: [25, 587], perAttemptTimeoutMs: 200, cache },
     });
     expect(first.port).toBe(587);
     expect(first.portCached).toBe(false);
@@ -133,7 +133,7 @@ describe('0110 SMTP Verifier Unit', () => {
       local: 'second',
       domain: 'example.com',
       mxRecords: ['mx.example.com'],
-      options: { ports: [25, 587], timeout: 200, cache },
+      options: { ports: [25, 587], perAttemptTimeoutMs: 200, cache },
     });
     expect(second.port).toBe(587);
     expect(second.portCached).toBe(true);
@@ -158,7 +158,7 @@ describe('0110 SMTP Verifier Unit', () => {
       local: 'john',
       domain: 'example.com',
       mxRecords: ['mx.example.com'],
-      options: { ports: [25], timeout: 200, sequence },
+      options: { ports: [25], perAttemptTimeoutMs: 200, sequence },
     });
 
     // The caller's sequence object should be unmutated — the verifier maps EHLO→HELO
@@ -173,7 +173,7 @@ describe('0110 SMTP Verifier Unit', () => {
       local: 'john',
       domain: 'example.com',
       mxRecords: ['mx.example.com'],
-      options: { ports: [25, 587], timeout: 100 },
+      options: { ports: [25, 587], perAttemptTimeoutMs: 100 },
     });
 
     expect(port).toBe(0);

--- a/__tests__/unit/0111-smtp-dsn.test.ts
+++ b/__tests__/unit/0111-smtp-dsn.test.ts
@@ -65,7 +65,7 @@ describe('0111 isInvalidMailboxError — DSN class-7 carve-out', () => {
       local: 'missing',
       domain: 'example.com',
       mxRecords: ['mx.example.com'],
-      options: { ports: [587], timeout: 200 },
+      options: { ports: [587], perAttemptTimeoutMs: 200 },
     });
     expect(smtpResult.isDeliverable).toBe(false);
     expect(smtpResult.error).toBe('not_found');
@@ -77,7 +77,7 @@ describe('0111 isInvalidMailboxError — DSN class-7 carve-out', () => {
       local: 'real-user',
       domain: 'example.com',
       mxRecords: ['mx.example.com'],
-      options: { ports: [587], timeout: 200 },
+      options: { ports: [587], perAttemptTimeoutMs: 200 },
     });
     // Result must be ambiguous (canConnectSmtp false → null), NOT a hard "not deliverable" verdict.
     expect(smtpResult.error).not.toBe('not_found');
@@ -89,7 +89,7 @@ describe('0111 isInvalidMailboxError — DSN class-7 carve-out', () => {
       local: 'real-user',
       domain: 'example.com',
       mxRecords: ['mx.example.com'],
-      options: { ports: [587], timeout: 200 },
+      options: { ports: [587], perAttemptTimeoutMs: 200 },
     });
     expect(smtpResult.error).not.toBe('not_found');
   });
@@ -103,7 +103,7 @@ describe('0111 isInvalidMailboxError — DSN class-7 carve-out', () => {
       local: 'user',
       domain: 'example.com',
       mxRecords: ['mx.example.com'],
-      options: { ports: [587], timeout: 200 },
+      options: { ports: [587], perAttemptTimeoutMs: 200 },
     });
     // High-volume heuristic fires before the policy-block guard.
     expect(smtpResult.isDeliverable).toBe(true);
@@ -117,7 +117,7 @@ describe('0111 isInvalidMailboxError — DSN class-7 carve-out', () => {
       local: 'missing',
       domain: 'example.com',
       mxRecords: ['mx.example.com'],
-      options: { ports: [587], timeout: 200 },
+      options: { ports: [587], perAttemptTimeoutMs: 200 },
     });
     expect(smtpResult.isDeliverable).toBe(false);
     expect(smtpResult.error).toBe('not_found');

--- a/__tests__/unit/0113-smtp-transcript.test.ts
+++ b/__tests__/unit/0113-smtp-transcript.test.ts
@@ -32,7 +32,7 @@ describe('0113 SMTP transcript capture', () => {
       local: 'alice',
       domain: 'example.com',
       mxRecords: ['mx.example.com'],
-      options: { ports: [25], timeout: 200 },
+      options: { ports: [25], perAttemptTimeoutMs: 200 },
     });
     expect(smtpResult.transcript).toBeUndefined();
     expect(smtpResult.commands).toBeUndefined();
@@ -44,7 +44,7 @@ describe('0113 SMTP transcript capture', () => {
       local: 'alice',
       domain: 'example.com',
       mxRecords: ['mx.example.com'],
-      options: { ports: [25], timeout: 200, captureTranscript: true },
+      options: { ports: [25], perAttemptTimeoutMs: 200, captureTranscript: true },
     });
     expect(Array.isArray(smtpResult.transcript)).toBe(true);
     expect(Array.isArray(smtpResult.commands)).toBe(true);
@@ -58,7 +58,7 @@ describe('0113 SMTP transcript capture', () => {
       local: 'alice',
       domain: 'example.com',
       mxRecords: ['mx.example.com'],
-      options: { ports: [25], timeout: 200, captureTranscript: true },
+      options: { ports: [25], perAttemptTimeoutMs: 200, captureTranscript: true },
     });
     for (const line of smtpResult.transcript ?? []) {
       expect(line.startsWith('mx.example.com:25|s| ')).toBe(true);
@@ -71,7 +71,7 @@ describe('0113 SMTP transcript capture', () => {
       local: 'alice',
       domain: 'example.com',
       mxRecords: ['mx.example.com'],
-      options: { ports: [25], timeout: 200, captureTranscript: true },
+      options: { ports: [25], perAttemptTimeoutMs: 200, captureTranscript: true },
     });
     for (const cmd of smtpResult.commands ?? []) {
       expect(cmd.startsWith('mx.example.com:25|c| ')).toBe(true);
@@ -84,7 +84,7 @@ describe('0113 SMTP transcript capture', () => {
       local: 'alice',
       domain: 'example.com',
       mxRecords: ['mx.example.com'],
-      options: { ports: [25], timeout: 200, captureTranscript: true },
+      options: { ports: [25], perAttemptTimeoutMs: 200, captureTranscript: true },
     });
     const transcript = smtpResult.transcript!;
     // We sent 4 commands → got 4 replies (greeting + 3 step responses).
@@ -100,7 +100,7 @@ describe('0113 SMTP transcript capture', () => {
       local: 'alice',
       domain: 'example.com',
       mxRecords: ['mx.example.com'],
-      options: { ports: [25], timeout: 200, captureTranscript: true },
+      options: { ports: [25], perAttemptTimeoutMs: 200, captureTranscript: true },
     });
     const cmds = smtpResult.commands!;
     expect(cmds.some((c) => c.includes('EHLO'))).toBe(true);
@@ -122,7 +122,7 @@ describe('0113 SMTP transcript capture', () => {
       local: 'alice',
       domain: 'example.com',
       mxRecords: ['mx.example.com'],
-      options: { ports: [25, 587], timeout: 50, captureTranscript: true },
+      options: { ports: [25, 587], perAttemptTimeoutMs: 50, captureTranscript: true },
     });
     const transcript = smtpResult.transcript ?? [];
     const commands = smtpResult.commands ?? [];
@@ -138,7 +138,7 @@ describe('0113 SMTP transcript capture', () => {
       local: 'missing',
       domain: 'example.com',
       mxRecords: ['mx.example.com'],
-      options: { ports: [25], timeout: 200, captureTranscript: true },
+      options: { ports: [25], perAttemptTimeoutMs: 200, captureTranscript: true },
     });
     expect(smtpResult.isDeliverable).toBe(false);
     expect(smtpResult.transcript!.some((l) => l.includes('550 5.1.1 user unknown'))).toBe(true);
@@ -150,7 +150,7 @@ describe('0113 SMTP transcript capture', () => {
       local: 'alice',
       domain: 'example.com',
       mxRecords: ['mx.example.com'],
-      options: { ports: [25], timeout: 200, captureTranscript: true },
+      options: { ports: [25], perAttemptTimeoutMs: 200, captureTranscript: true },
     });
     first.smtpResult.transcript!.push('garbage');
     first.smtpResult.commands!.push('garbage');
@@ -160,7 +160,7 @@ describe('0113 SMTP transcript capture', () => {
       local: 'bob',
       domain: 'example.com',
       mxRecords: ['mx.example.com'],
-      options: { ports: [25], timeout: 200, captureTranscript: true },
+      options: { ports: [25], perAttemptTimeoutMs: 200, captureTranscript: true },
     });
     expect(second.smtpResult.transcript).not.toContain('garbage');
     expect(second.smtpResult.commands).not.toContain('garbage');
@@ -172,7 +172,7 @@ describe('0113 SMTP transcript capture', () => {
       local: 'alice',
       domain: 'example.com',
       mxRecords: ['mx.example.com'],
-      options: { ports: [25, 587], timeout: 100, captureTranscript: true },
+      options: { ports: [25, 587], perAttemptTimeoutMs: 100, captureTranscript: true },
     });
     // Error mirrors the LAST attempt's reason, not a generic message.
     expect(smtpResult.error).toBe('connection_error');

--- a/__tests__/unit/0114-smtp-features.test.ts
+++ b/__tests__/unit/0114-smtp-features.test.ts
@@ -54,7 +54,7 @@ describe('0114 SMTP — multi-MX iteration', () => {
       local: 'alice',
       domain: 'example.com',
       mxRecords: ['mx1.example.com', 'mx2.example.com'],
-      options: { ports: [25, 587], timeout: 200 },
+      options: { ports: [25, 587], perAttemptTimeoutMs: 200 },
     });
 
     expect(smtpResult.isDeliverable).toBe(true);
@@ -79,7 +79,7 @@ describe('0114 SMTP — multi-MX iteration', () => {
       local: 'missing',
       domain: 'example.com',
       mxRecords: ['mx1.example.com', 'mx2.example.com'],
-      options: { ports: [25], timeout: 200 },
+      options: { ports: [25], perAttemptTimeoutMs: 200 },
     });
 
     expect(smtpResult.isDeliverable).toBe(false);
@@ -96,7 +96,7 @@ describe('0114 SMTP — multi-MX iteration', () => {
       local: 'alice',
       domain: 'example.com',
       mxRecords: ['mx1.example.com', 'mx2.example.com'],
-      options: { ports: [25], timeout: 100 },
+      options: { ports: [25], perAttemptTimeoutMs: 100 },
     });
 
     expect(smtpResult.isDeliverable).toBe(false);
@@ -112,7 +112,7 @@ describe('0114 SMTP — multi-MX iteration', () => {
       local: 'alice',
       domain: 'example.com',
       mxRecords: ['mx.example.com'],
-      options: { ports: [-1, 65536], timeout: 50 },
+      options: { ports: [-1, 65536], perAttemptTimeoutMs: 50 },
     });
 
     expect(smtpResult.isDeliverable).toBe(false);
@@ -131,7 +131,7 @@ describe('0114 SMTP — catch-all detection (always-on dual-probe)', () => {
       local: 'alice',
       domain: 'example.com',
       mxRecords: ['mx.example.com'],
-      options: { ports: [25], timeout: 200, pipelining: 'never' },
+      options: { ports: [25], perAttemptTimeoutMs: 200, pipelining: 'never' },
     });
 
     expect(smtpResult.isDeliverable).toBe(true);
@@ -145,7 +145,7 @@ describe('0114 SMTP — catch-all detection (always-on dual-probe)', () => {
       local: 'alice',
       domain: 'example.com',
       mxRecords: ['mx.example.com'],
-      options: { ports: [25], timeout: 200, pipelining: 'never' },
+      options: { ports: [25], perAttemptTimeoutMs: 200, pipelining: 'never' },
     });
 
     expect(smtpResult.isDeliverable).toBe(true);
@@ -159,7 +159,7 @@ describe('0114 SMTP — catch-all detection (always-on dual-probe)', () => {
       local: 'missing',
       domain: 'example.com',
       mxRecords: ['mx.example.com'],
-      options: { ports: [25], timeout: 200, pipelining: 'never' },
+      options: { ports: [25], perAttemptTimeoutMs: 200, pipelining: 'never' },
     });
 
     // No second RCPT (probe) command should be on the wire.
@@ -177,7 +177,7 @@ describe('0114 SMTP — catch-all detection (always-on dual-probe)', () => {
       local: 'full',
       domain: 'example.com',
       mxRecords: ['mx.example.com'],
-      options: { ports: [25], timeout: 200, pipelining: 'never' },
+      options: { ports: [25], perAttemptTimeoutMs: 200, pipelining: 'never' },
     });
 
     expect(smtpResult.isDeliverable).toBe(false);
@@ -197,7 +197,7 @@ describe('0114 SMTP — catch-all detection (always-on dual-probe)', () => {
       mxRecords: ['mx.example.com'],
       options: {
         ports: [25],
-        timeout: 200,
+        perAttemptTimeoutMs: 200,
         pipelining: 'never',
         catchAllProbeLocal: (realLocal, domain) => {
           captured.realLocal = realLocal;
@@ -233,7 +233,7 @@ describe('0114 SMTP — PIPELINING (RFC 2920)', () => {
       local: 'alice',
       domain: 'example.com',
       mxRecords: ['mx.example.com'],
-      options: { ports: [25], timeout: 300, pipelining: 'auto' },
+      options: { ports: [25], perAttemptTimeoutMs: 300, pipelining: 'auto' },
     });
 
     // Look at writes after MAIL FROM. With pipelining, the envelope (RCPT real
@@ -251,7 +251,7 @@ describe('0114 SMTP — PIPELINING (RFC 2920)', () => {
       local: 'alice',
       domain: 'example.com',
       mxRecords: ['mx.example.com'],
-      options: { ports: [25], timeout: 300, pipelining: 'auto' },
+      options: { ports: [25], perAttemptTimeoutMs: 300, pipelining: 'auto' },
     });
 
     const rcptWrites = fakeNet.writes.filter((w) => w.data.startsWith('RCPT TO:'));
@@ -277,7 +277,7 @@ describe('0114 SMTP — PIPELINING (RFC 2920)', () => {
       local: 'alice',
       domain: 'example.com',
       mxRecords: ['mx.example.com'],
-      options: { ports: [25], timeout: 300, pipelining: 'never' },
+      options: { ports: [25], perAttemptTimeoutMs: 300, pipelining: 'never' },
     });
 
     const rcptWrites = fakeNet.writes.filter((w) => w.data.startsWith('RCPT TO:'));
@@ -298,7 +298,7 @@ describe('0114 SMTP — PIPELINING (RFC 2920)', () => {
       local: 'alice',
       domain: 'example.com',
       mxRecords: ['mx.example.com'],
-      options: { ports: [25], timeout: 300, pipelining: 'force' },
+      options: { ports: [25], perAttemptTimeoutMs: 300, pipelining: 'force' },
     });
 
     const envelopeWrites = fakeNet.writes.filter((w) => w.data.includes('RCPT TO:') || w.data.startsWith('RSET'));
@@ -317,7 +317,7 @@ describe('0114 SMTP — enhancedStatus (RFC 3463)', () => {
       local: 'missing',
       domain: 'example.com',
       mxRecords: ['mx.example.com'],
-      options: { ports: [25], timeout: 200, pipelining: 'never' },
+      options: { ports: [25], perAttemptTimeoutMs: 200, pipelining: 'never' },
     });
 
     expect(smtpResult.enhancedStatus).toBe('5.1.1');
@@ -330,7 +330,7 @@ describe('0114 SMTP — enhancedStatus (RFC 3463)', () => {
       local: 'alice',
       domain: 'example.com',
       mxRecords: ['mx.example.com'],
-      options: { ports: [25], timeout: 200, pipelining: 'never' },
+      options: { ports: [25], perAttemptTimeoutMs: 200, pipelining: 'never' },
     });
 
     // The probe-RCPT 550 line in our envelope DOES contain '5.1.1' — so the
@@ -348,7 +348,7 @@ describe('0114 SMTP — enhancedStatus (RFC 3463)', () => {
       local: 'alice',
       domain: 'example.com',
       mxRecords: ['mx.example.com'],
-      options: { ports: [25], timeout: 200 },
+      options: { ports: [25], perAttemptTimeoutMs: 200 },
     });
 
     expect(smtpResult.enhancedStatus).toBe('4.7.0');
@@ -361,7 +361,7 @@ describe('0114 SMTP — enhancedStatus (RFC 3463)', () => {
       local: 'missing',
       domain: 'example.com',
       mxRecords: ['mx.example.com'],
-      options: { ports: [25], timeout: 200, pipelining: 'never' },
+      options: { ports: [25], perAttemptTimeoutMs: 200, pipelining: 'never' },
     });
 
     expect(smtpResult.responseCode).toBe(550);
@@ -381,7 +381,7 @@ describe('0114 SMTP — enhancedStatus (RFC 3463)', () => {
       local: 'alice',
       domain: 'example.com',
       mxRecords: ['mx.example.com'],
-      options: { ports: [25], timeout: 200, pipelining: 'never' },
+      options: { ports: [25], perAttemptTimeoutMs: 200, pipelining: 'never' },
     });
 
     expect(smtpResult.enhancedStatus).toBe('5.7.1');
@@ -399,7 +399,7 @@ describe('0114 SMTP — metrics', () => {
       local: 'alice',
       domain: 'example.com',
       mxRecords: ['mx.example.com'],
-      options: { ports: [25], timeout: 200 },
+      options: { ports: [25], perAttemptTimeoutMs: 200 },
     });
 
     expect(smtpResult.metrics).toBeDefined();
@@ -419,7 +419,7 @@ describe('0114 SMTP — metrics', () => {
       local: 'alice',
       domain: 'example.com',
       mxRecords: ['mx1.example.com', 'mx2.example.com'],
-      options: { ports: [25, 587], timeout: 200 },
+      options: { ports: [25, 587], perAttemptTimeoutMs: 200 },
     });
 
     expect(smtpResult.isDeliverable).toBe(true);
@@ -436,7 +436,7 @@ describe('0114 SMTP — metrics', () => {
       local: 'alice',
       domain: 'example.com',
       mxRecords: ['mx1.example.com', 'mx2.example.com'],
-      options: { ports: [25], timeout: 100 },
+      options: { ports: [25], perAttemptTimeoutMs: 100 },
     });
 
     expect(smtpResult.isDeliverable).toBe(false);
@@ -451,7 +451,7 @@ describe('0114 SMTP — metrics', () => {
       local: 'alice',
       domain: 'example.com',
       mxRecords: [],
-      options: { timeout: 50 },
+      options: { perAttemptTimeoutMs: 50 },
     });
 
     expect(smtpResult.error).toBe('no_mx_records');

--- a/__tests__/unit/0115-smtp-starttls.test.ts
+++ b/__tests__/unit/0115-smtp-starttls.test.ts
@@ -42,7 +42,7 @@ describe('0115 SMTP — STARTTLS opt-in / opt-out', () => {
       local: 'alice',
       domain: 'example.com',
       mxRecords: ['mx.example.com'],
-      options: { ports: [587], timeout: 200, startTls: 'auto', pipelining: 'never' },
+      options: { ports: [587], perAttemptTimeoutMs: 200, startTls: 'auto', pipelining: 'never' },
     });
 
     const startTlsCommands = fakeNet.writes.filter((w) => w.data.startsWith('STARTTLS'));
@@ -56,7 +56,7 @@ describe('0115 SMTP — STARTTLS opt-in / opt-out', () => {
       local: 'alice',
       domain: 'example.com',
       mxRecords: ['mx.example.com'],
-      options: { ports: [587], timeout: 200, startTls: 'auto', pipelining: 'never' },
+      options: { ports: [587], perAttemptTimeoutMs: 200, startTls: 'auto', pipelining: 'never' },
     });
 
     const startTlsCommands = fakeNet.writes.filter((w) => w.data.startsWith('STARTTLS'));
@@ -72,7 +72,7 @@ describe('0115 SMTP — STARTTLS opt-in / opt-out', () => {
       local: 'alice',
       domain: 'example.com',
       mxRecords: ['mx.example.com'],
-      options: { ports: [587], timeout: 200, startTls: 'never', pipelining: 'never' },
+      options: { ports: [587], perAttemptTimeoutMs: 200, startTls: 'never', pipelining: 'never' },
     });
 
     const startTlsCommands = fakeNet.writes.filter((w) => w.data.startsWith('STARTTLS'));
@@ -88,7 +88,7 @@ describe('0115 SMTP — STARTTLS opt-in / opt-out', () => {
       local: 'alice',
       domain: 'example.com',
       mxRecords: ['mx.example.com'],
-      options: { ports: [587], timeout: 200, startTls: 'force', pipelining: 'never' },
+      options: { ports: [587], perAttemptTimeoutMs: 200, startTls: 'force', pipelining: 'never' },
     });
 
     const startTlsCommands = fakeNet.writes.filter((w) => w.data.startsWith('STARTTLS'));
@@ -103,7 +103,7 @@ describe('0115 SMTP — STARTTLS opt-in / opt-out', () => {
       local: 'alice',
       domain: 'example.com',
       mxRecords: ['mx.example.com'],
-      options: { ports: [465], timeout: 200, startTls: 'auto', pipelining: 'never' },
+      options: { ports: [465], perAttemptTimeoutMs: 200, startTls: 'auto', pipelining: 'never' },
     });
 
     const startTlsCommands = fakeNet.writes.filter((w) => w.data.startsWith('STARTTLS'));
@@ -117,7 +117,7 @@ describe('0115 SMTP — STARTTLS opt-in / opt-out', () => {
       local: 'alice',
       domain: 'example.com',
       mxRecords: ['mx.example.com'],
-      options: { ports: [587], timeout: 200, startTls: 'auto', pipelining: 'never' },
+      options: { ports: [587], perAttemptTimeoutMs: 200, startTls: 'auto', pipelining: 'never' },
     });
 
     expect(smtpResult.error).toBe('tls_upgrade_failed');
@@ -131,7 +131,7 @@ describe('0115 SMTP — STARTTLS opt-in / opt-out', () => {
       local: 'alice',
       domain: 'example.com',
       mxRecords: ['mx.example.com'],
-      options: { ports: [25], timeout: 200, startTls: 'auto', pipelining: 'never' },
+      options: { ports: [25], perAttemptTimeoutMs: 200, startTls: 'auto', pipelining: 'never' },
     });
 
     const startTlsCommands = fakeNet.writes.filter((w) => w.data.startsWith('STARTTLS'));
@@ -146,7 +146,7 @@ describe('0115 SMTP — STARTTLS opt-in / opt-out', () => {
       local: 'alice',
       domain: 'example.com',
       mxRecords: ['mx.example.com'],
-      options: { ports: [587], timeout: 200, pipelining: 'never' },
+      options: { ports: [587], perAttemptTimeoutMs: 200, pipelining: 'never' },
     });
 
     // Default behavior should be 'auto' (i.e. attempt the upgrade when advertised).

--- a/__tests__/unit/0117-smtp-control-options.test.ts
+++ b/__tests__/unit/0117-smtp-control-options.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Control-option tests for `verifyMailboxSMTP`:
+ *
+ *   - `totalDeadlineMs`        — wall-clock cap across all MX × port attempts
+ *   - `maxConsecutiveFailures` — stop after N connection-class failures in a row
+ *   - `maxMxHosts`             — limit MX walk to first N hostnames
+ *   - `retry`                  — retry connection-class failures on the same MX × port
+ *
+ * fake-net's mock can simulate per-port connection errors and unresponsive ports,
+ * which is enough to drive every option through its decision path.
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { verifyMailboxSMTP } from '../../src/smtp-verifier';
+import { fakeNet } from '../helpers/fake-net';
+
+describe('0117 SMTP — totalDeadlineMs', () => {
+  beforeEach(() => fakeNet.reset());
+  afterEach(() => fakeNet.reset());
+
+  it('aborts the MX walk once the deadline elapses (does not start more attempts)', async () => {
+    // 3 MXes × 1 port (25), each unresponsive → each attempt takes ~per-attempt timeout.
+    // Set per-attempt timeout 100ms, deadline 150ms. We should see 1–2 attempts, not 3.
+    fakeNet.setUnresponsivePorts([25]);
+
+    const start = Date.now();
+    const { smtpResult } = await verifyMailboxSMTP({
+      local: 'alice',
+      domain: 'example.com',
+      mxRecords: ['mx1.example.com', 'mx2.example.com', 'mx3.example.com'],
+      options: { ports: [25], perAttemptTimeoutMs: 100, totalDeadlineMs: 150 },
+    });
+    const elapsed = Date.now() - start;
+
+    expect(smtpResult.isDeliverable).toBe(false);
+    // Wall-clock should be well under "all 3 attempts × 100ms = 300ms".
+    expect(elapsed).toBeLessThan(300);
+    // metrics.mxHostsTried should reflect the early stop.
+    expect(smtpResult.metrics?.mxAttempts).toBeLessThanOrEqual(3);
+  });
+});
+
+describe('0117 SMTP — maxConsecutiveFailures', () => {
+  beforeEach(() => fakeNet.reset());
+  afterEach(() => fakeNet.reset());
+
+  it('stops after N consecutive connection failures', async () => {
+    // All ports refuse → each MX × port pair fails with `connection_error`.
+    // Set maxConsecutiveFailures = 2 → we should see exactly 2 attempts.
+    fakeNet.setConnectError('ECONNREFUSED');
+
+    const { smtpResult } = await verifyMailboxSMTP({
+      local: 'alice',
+      domain: 'example.com',
+      mxRecords: ['mx1.example.com', 'mx2.example.com', 'mx3.example.com'],
+      options: { ports: [25, 587, 465], perAttemptTimeoutMs: 100, maxConsecutiveFailures: 2 },
+    });
+
+    expect(smtpResult.isDeliverable).toBe(false);
+    expect(smtpResult.metrics?.portAttempts).toBe(2);
+  });
+
+  it('counter resets on a non-connection-class outcome', async () => {
+    // First attempt: 550 (mailbox not found, NOT a connection failure → counter resets)
+    // Subsequent: connection refused
+    // With maxConsecutiveFailures=2, we'd stop after 2 consecutive *connection* failures.
+    fakeNet.script(['220 mx1 hi', '250 ok', '250 ok', '550 5.1.1 user unknown']);
+
+    const { smtpResult } = await verifyMailboxSMTP({
+      local: 'missing',
+      domain: 'example.com',
+      mxRecords: ['mx1.example.com'],
+      options: { ports: [25], perAttemptTimeoutMs: 100, maxConsecutiveFailures: 2 },
+    });
+
+    // 550 short-circuits the search — definitive answer trumps the early-stop rule.
+    expect(smtpResult.isDeliverable).toBe(false);
+    expect(smtpResult.error).toBe('not_found');
+  });
+});
+
+describe('0117 SMTP — maxMxHosts', () => {
+  beforeEach(() => fakeNet.reset());
+  afterEach(() => fakeNet.reset());
+
+  it('limits the MX walk to the first N hostnames', async () => {
+    fakeNet.setConnectError('ECONNREFUSED');
+
+    const { smtpResult } = await verifyMailboxSMTP({
+      local: 'alice',
+      domain: 'example.com',
+      mxRecords: ['mx1.example.com', 'mx2.example.com', 'mx3.example.com', 'mx4.example.com'],
+      options: { ports: [25], perAttemptTimeoutMs: 100, maxMxHosts: 2 },
+    });
+
+    expect(smtpResult.metrics?.mxAttempts).toBe(2);
+    expect(smtpResult.metrics?.mxHostsTried).toEqual(['mx1.example.com', 'mx2.example.com']);
+  });
+});
+
+describe('0117 SMTP — retry policy', () => {
+  beforeEach(() => fakeNet.reset());
+  afterEach(() => fakeNet.reset());
+
+  it('retries connection-class failures up to `attempts` times before moving on', async () => {
+    fakeNet.setConnectError('ECONNREFUSED');
+
+    const { smtpResult } = await verifyMailboxSMTP({
+      local: 'alice',
+      domain: 'example.com',
+      mxRecords: ['mx1.example.com'],
+      options: {
+        ports: [25],
+        perAttemptTimeoutMs: 50,
+        retry: { attempts: 2, delayMs: 5, backoff: 'fixed' },
+      },
+    });
+
+    // Initial attempt + 2 retries = 3 connection attempts on the same MX × port.
+    expect(smtpResult.metrics?.portAttempts).toBe(3);
+  });
+
+  it('does NOT retry definitive answers (250 / 550)', async () => {
+    // Real RCPT 550 → not_found, no retry.
+    fakeNet.script(['220 mx hi', '250 ok', '250 ok', '550 5.1.1 user unknown']);
+
+    const { smtpResult } = await verifyMailboxSMTP({
+      local: 'missing',
+      domain: 'example.com',
+      mxRecords: ['mx.example.com'],
+      options: {
+        ports: [25],
+        perAttemptTimeoutMs: 50,
+        retry: { attempts: 5, delayMs: 5 },
+      },
+    });
+
+    expect(smtpResult.error).toBe('not_found');
+    expect(smtpResult.metrics?.portAttempts).toBe(1); // no retries on definitive answers
+  });
+
+  it('exponential backoff doubles the delay between retries', async () => {
+    fakeNet.setConnectError('ECONNREFUSED');
+
+    const start = Date.now();
+    await verifyMailboxSMTP({
+      local: 'alice',
+      domain: 'example.com',
+      mxRecords: ['mx.example.com'],
+      options: {
+        ports: [25],
+        perAttemptTimeoutMs: 50,
+        retry: { attempts: 2, delayMs: 50, backoff: 'exponential' },
+      },
+    });
+    const elapsed = Date.now() - start;
+
+    // Expected delays: retry 1 at 50ms, retry 2 at 100ms = 150ms total backoff.
+    // Connection errors fire ~immediately on a refused port, so most of the
+    // wall-clock IS the backoff. Allow 50% slack for scheduling jitter.
+    expect(elapsed).toBeGreaterThanOrEqual(120);
+  });
+});

--- a/__tests__/unit/0118-presets.test.ts
+++ b/__tests__/unit/0118-presets.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Smoke tests for the configuration presets exported from
+ * `@emailcheck/email-validator-js` — `SMTP_PRESETS` (for `verifyMailboxSMTP`)
+ * and `VERIFY_EMAIL_PRESETS` (for `verifyEmail`).
+ *
+ * These don't exhaustively re-test the underlying options — `0117-smtp-control-options.test.ts`
+ * covers each option's behavior. Here we just confirm:
+ *   - presets are exported
+ *   - their shapes match the option types
+ *   - the field names are spreadable into the relevant params object
+ */
+import { describe, expect, it } from 'bun:test';
+import { SMTP_PRESETS, VERIFY_EMAIL_PRESETS } from '../../src';
+
+describe('0118 presets — SMTP_PRESETS', () => {
+  it('exports four named presets', () => {
+    expect(Object.keys(SMTP_PRESETS).sort()).toEqual(['batch', 'dedicated', 'fast', 'serverless']);
+  });
+
+  it('serverless: tight latency budget — bounded total deadline + max-MX', () => {
+    expect(SMTP_PRESETS.serverless.totalDeadlineMs).toBe(5000);
+    expect(SMTP_PRESETS.serverless.maxConsecutiveFailures).toBe(3);
+    expect(SMTP_PRESETS.serverless.maxMxHosts).toBe(2);
+    // No retries — fail fast on tight handlers.
+    expect('retry' in SMTP_PRESETS.serverless).toBe(false);
+  });
+
+  it('dedicated: not latency-bound, retries connection-class failures once', () => {
+    expect(SMTP_PRESETS.dedicated.retry).toEqual({
+      attempts: 1,
+      delayMs: 500,
+      backoff: 'exponential',
+    });
+    expect(SMTP_PRESETS.dedicated.totalDeadlineMs).toBe(30_000);
+  });
+
+  it('batch: longer deadlines, two retries with exponential backoff', () => {
+    expect(SMTP_PRESETS.batch.retry?.attempts).toBe(2);
+    expect(SMTP_PRESETS.batch.retry?.backoff).toBe('exponential');
+    expect(SMTP_PRESETS.batch.totalDeadlineMs).toBe(60_000);
+  });
+
+  it('fast: sub-3s wall-clock, single MX', () => {
+    expect(SMTP_PRESETS.fast.totalDeadlineMs).toBe(3000);
+    expect(SMTP_PRESETS.fast.maxMxHosts).toBe(1);
+  });
+
+  it('every preset is spreadable into SMTPVerifyOptions without TS error', () => {
+    // Compile-time assertion — if this typechecks, the shape is correct.
+    const opts1 = { ...SMTP_PRESETS.serverless, ports: [25, 587] };
+    const opts2 = { ...SMTP_PRESETS.fast, debug: true };
+    expect(opts1.ports).toEqual([25, 587]);
+    expect(opts2.debug).toBe(true);
+  });
+});
+
+describe('0118 presets — VERIFY_EMAIL_PRESETS', () => {
+  it('exports four named presets matching SMTP_PRESETS', () => {
+    expect(Object.keys(VERIFY_EMAIL_PRESETS).sort()).toEqual(['batch', 'dedicated', 'fast', 'serverless']);
+  });
+
+  it('uses the smtp-prefixed VerifyEmailParams field names', () => {
+    expect(VERIFY_EMAIL_PRESETS.serverless.smtpTotalDeadlineMs).toBe(5000);
+    expect(VERIFY_EMAIL_PRESETS.serverless.smtpMaxConsecutiveFailures).toBe(3);
+    expect(VERIFY_EMAIL_PRESETS.serverless.smtpMaxMxHosts).toBe(2);
+    expect(VERIFY_EMAIL_PRESETS.serverless.whoisTimeoutMs).toBe(3000);
+  });
+
+  it('values match the unprefixed SMTP_PRESETS field-for-field', () => {
+    // serverless
+    expect(VERIFY_EMAIL_PRESETS.serverless.smtpPerAttemptTimeoutMs).toBe(SMTP_PRESETS.serverless.perAttemptTimeoutMs);
+    expect(VERIFY_EMAIL_PRESETS.serverless.smtpTotalDeadlineMs).toBe(SMTP_PRESETS.serverless.totalDeadlineMs);
+    // dedicated
+    expect(VERIFY_EMAIL_PRESETS.dedicated.smtpRetry).toEqual(SMTP_PRESETS.dedicated.retry);
+    // batch
+    expect(VERIFY_EMAIL_PRESETS.batch.smtpRetry).toEqual(SMTP_PRESETS.batch.retry);
+    // fast
+    expect(VERIFY_EMAIL_PRESETS.fast.smtpMaxMxHosts).toBe(SMTP_PRESETS.fast.maxMxHosts);
+  });
+
+  it('every preset is spreadable into VerifyEmailParams without TS error', () => {
+    const params = {
+      emailAddress: 'alice@example.com',
+      ...VERIFY_EMAIL_PRESETS.serverless,
+      verifySmtp: true,
+    };
+    expect(params.emailAddress).toBe('alice@example.com');
+    expect(params.verifySmtp).toBe(true);
+  });
+});

--- a/__tests__/utils/smtp.test.config.ts
+++ b/__tests__/utils/smtp.test.config.ts
@@ -40,37 +40,37 @@ export const TEST_CONFIGS = {
   // Port configurations
   SINGLE_PORT_25: {
     ports: [25],
-    timeout: 5000,
+    perAttemptTimeoutMs: 5000,
   },
 
   SINGLE_PORT_587: {
     ports: [587],
-    timeout: 5000,
+    perAttemptTimeoutMs: 5000,
   },
 
   SINGLE_PORT_465: {
     ports: [465],
-    timeout: 5000,
+    perAttemptTimeoutMs: 5000,
   },
 
   SECURE_PORTS_ONLY: {
     ports: [587, 465],
-    timeout: 5000,
+    perAttemptTimeoutMs: 5000,
   },
 
   // TLS configurations
   TLS_DISABLED: {
-    tls: false,
+    tlsConfig: false,
     ports: [25],
   },
 
   TLS_ENABLED: {
-    tls: true,
+    tlsConfig: true,
     ports: [587, 465],
   },
 
   TLS_STRICT: {
-    tls: {
+    tlsConfig: {
       rejectUnauthorized: true,
       minVersion: 'TLSv1.3' as const,
     },
@@ -78,7 +78,7 @@ export const TEST_CONFIGS = {
   },
 
   TLS_LENIENT: {
-    tls: {
+    tlsConfig: {
       rejectUnauthorized: false,
       minVersion: 'TLSv1.2' as const,
     },
@@ -87,15 +87,15 @@ export const TEST_CONFIGS = {
 
   // Timeout configurations
   FAST: {
-    timeout: 2000,
+    perAttemptTimeoutMs: 2000,
   },
 
   SLOW: {
-    timeout: 10000,
+    perAttemptTimeoutMs: 10000,
   },
 
   VERY_SLOW: {
-    timeout: 30000,
+    perAttemptTimeoutMs: 30000,
   },
 } as const;
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -120,7 +120,7 @@ const { smtpResult } = await verifyMailboxSMTP({
   local: 'alice',
   domain: 'example.com',
   mxRecords: ['mx.example.com'],
-  options: { ports: [25, 587], timeout: 5000, captureTranscript: true },
+  options: { ports: [25, 587], perAttemptTimeoutMs: 5000, captureTranscript: true },
 });
 
 console.log(smtpResult.transcript); // ["25|s| 220 mx ESMTP", ...]

--- a/examples/high-level/advanced-usage.ts
+++ b/examples/high-level/advanced-usage.ts
@@ -14,7 +14,7 @@ async function basicUsage() {
     emailAddress: 'user@example.com',
     verifyMx: true,
     verifySmtp: true,
-    timeout: 5000,
+    smtpPerAttemptTimeoutMs: 5000,
   });
 
   console.log('Valid format:', result.validFormat);
@@ -31,7 +31,7 @@ async function detailedVerification() {
     verifySmtp: false,
     checkDisposable: true,
     checkFree: true,
-    timeout: 5000,
+    smtpPerAttemptTimeoutMs: 5000,
   });
 
   console.log('Valid:', result.validFormat && result.validMx);
@@ -66,7 +66,7 @@ async function batchVerification() {
     verifySmtp: false,
     checkDisposable: true,
     checkFree: true,
-    timeout: 5000,
+    smtpPerAttemptTimeoutMs: 5000,
   });
 
   console.log('Summary:');

--- a/examples/smtp/caching.ts
+++ b/examples/smtp/caching.ts
@@ -141,7 +141,7 @@ async function demonstrateCustomCache() {
     mxRecords: ['gmail-smtp-in.l.google.com'],
     options: {
       ports: [25, 587, 465],
-      timeout: 5000,
+      perAttemptTimeoutMs: 5000,
       cache: customCache, // Pass the custom cache instance
       debug: true,
     },
@@ -159,7 +159,7 @@ async function demonstrateCustomCache() {
     mxRecords: ['gmail-smtp-in.l.google.com'],
     options: {
       ports: [25, 587, 465],
-      timeout: 5000,
+      perAttemptTimeoutMs: 5000,
       cache: customCache, // Same cache instance
       debug: true,
     },
@@ -181,7 +181,7 @@ async function demonstrateCustomCache() {
     mxRecords: ['outlook-com.olc.protection.outlook.com'],
     options: {
       ports: [25, 587, 465],
-      timeout: 5000,
+      perAttemptTimeoutMs: 5000,
       cache: customCache,
       debug: true,
     },
@@ -205,7 +205,7 @@ async function demonstrateDefaultCache() {
     mxRecords: ['gmail-smtp-in.l.google.com'],
     options: {
       ports: [25, 587, 465],
-      timeout: 5000,
+      perAttemptTimeoutMs: 5000,
       cache: defaultCache, // Use default cache
       debug: true,
     },
@@ -220,7 +220,7 @@ async function demonstrateDefaultCache() {
     mxRecords: ['gmail-smtp-in.l.google.com'],
     options: {
       ports: [25, 587, 465],
-      timeout: 5000,
+      perAttemptTimeoutMs: 5000,
       cache: defaultCache, // Same cache instance
       debug: true,
     },
@@ -235,7 +235,7 @@ async function demonstrateDefaultCache() {
     mxRecords: ['gmail-smtp-in.l.google.com'],
     options: {
       ports: [25, 587, 465],
-      timeout: 5000,
+      perAttemptTimeoutMs: 5000,
       cache: null, // No caching
       debug: true,
     },

--- a/examples/smtp/enhanced.ts
+++ b/examples/smtp/enhanced.ts
@@ -20,7 +20,7 @@ async function basicVerification(email: string) {
       domain,
       mxRecords: mxHosts,
       options: {
-        timeout: 5000,
+        perAttemptTimeoutMs: 5000,
         debug: true, // Enable debug logging
       },
     });
@@ -49,9 +49,9 @@ async function customPortVerification(email: string) {
       mxRecords: mxHosts,
       options: {
         ports: [587, 25], // Try STARTTLS first, then standard SMTP
-        timeout: 3000,
+        perAttemptTimeoutMs: 3000,
         debug: true,
-        tls: {
+        tlsConfig: {
           rejectUnauthorized: false, // For testing environments
           minVersion: 'TLSv1.2',
         },
@@ -81,10 +81,10 @@ async function secureVerification(email: string) {
       mxRecords: mxHosts,
       options: {
         cache: getDefaultCache(),
-        hostname: 'your-domain.com', // Use your actual domain
-        timeout: 10000, // Longer timeout for secure connections
+        heloHostname: 'your-domain.com', // Use your actual domain
+        perAttemptTimeoutMs: 10000, // Longer timeout for secure connections
         debug: true,
-        tls: {
+        tlsConfig: {
           rejectUnauthorized: true, // Strict certificate validation
           minVersion: 'TLSv1.3', // Require TLS 1.3
         },
@@ -115,9 +115,9 @@ async function testSpecificPort(email: string, port: number) {
       mxRecords: mxHosts,
       options: {
         ports: [port],
-        timeout: 3000,
+        perAttemptTimeoutMs: 3000,
         debug: true,
-        tls: {
+        tlsConfig: {
           rejectUnauthorized: false,
         },
       },
@@ -149,10 +149,10 @@ async function fastVerification(emails: string[]) {
         domain,
         mxRecords: mxHosts,
         options: {
-          timeout: 2000, // Short timeout
+          perAttemptTimeoutMs: 2000, // Short timeout
           debug: false, // No debug logging for speed
           cache: getDefaultCache(), // Enable caching
-          tls: {
+          tlsConfig: {
             rejectUnauthorized: false, // Skip validation for speed
           },
         },

--- a/examples/smtp/test.ts
+++ b/examples/smtp/test.ts
@@ -29,9 +29,9 @@ async function testPortConnectivity() {
         mxRecords,
         options: {
           ports: [port], // Test single port
-          timeout: 5000,
+          perAttemptTimeoutMs: 5000,
           debug: true,
-          tls: {
+          tlsConfig: {
             rejectUnauthorized: false,
             minVersion: 'TLSv1.2',
           },
@@ -59,7 +59,7 @@ async function testMultiPortWithCaching() {
     domain,
     mxRecords,
     options: {
-      timeout: 3000,
+      perAttemptTimeoutMs: 3000,
       cache: getDefaultCache(),
       debug: false,
     },
@@ -75,7 +75,7 @@ async function testMultiPortWithCaching() {
     domain,
     mxRecords,
     options: {
-      timeout: 3000,
+      perAttemptTimeoutMs: 3000,
       cache: getDefaultCache(),
       debug: false,
     },
@@ -104,7 +104,7 @@ async function testTimeoutHandling() {
     domain,
     mxRecords,
     options: {
-      timeout: 1, // 1ms timeout
+      perAttemptTimeoutMs: 1, // 1ms timeout
       debug: false,
     },
   });
@@ -128,8 +128,8 @@ async function testTLSConfiguration() {
     mxRecords,
     options: {
       ports: [465], // Try implicit TLS first
-      timeout: 5000,
-      tls: {
+      perAttemptTimeoutMs: 5000,
+      tlsConfig: {
         rejectUnauthorized: true,
         minVersion: 'TLSv1.3',
       },
@@ -146,8 +146,8 @@ async function testTLSConfiguration() {
     mxRecords,
     options: {
       ports: [465],
-      timeout: 5000,
-      tls: {
+      perAttemptTimeoutMs: 5000,
+      tlsConfig: {
         rejectUnauthorized: false,
         minVersion: 'TLSv1.2',
       },
@@ -172,7 +172,7 @@ async function testCustomSequences() {
     domain,
     mxRecords,
     options: {
-      timeout: 5000,
+      perAttemptTimeoutMs: 5000,
       debug: false,
     },
   });
@@ -185,7 +185,7 @@ async function testCustomSequences() {
     domain,
     mxRecords,
     options: {
-      timeout: 5000,
+      perAttemptTimeoutMs: 5000,
       debug: false,
     },
   });

--- a/examples/smtp/usage.ts
+++ b/examples/smtp/usage.ts
@@ -27,7 +27,7 @@ async function customPorts(email: string, mxRecords: string[]) {
     mxRecords,
     options: {
       ports: [587, 465], // Only try secure ports
-      timeout: 5000,
+      perAttemptTimeoutMs: 5000,
     },
   });
 }
@@ -42,12 +42,12 @@ async function secureVerify(email: string, mxRecords: string[]) {
     mxRecords,
     options: {
       ports: [465], // Only SMTPS with implicit TLS
-      timeout: 10000,
-      tls: {
+      perAttemptTimeoutMs: 10000,
+      tlsConfig: {
         rejectUnauthorized: true,
         minVersion: 'TLSv1.3',
       },
-      hostname: 'your-domain.com',
+      heloHostname: 'your-domain.com',
       cache: getDefaultCache(),
     },
   });
@@ -67,7 +67,7 @@ async function fastBulk(emails: string[], mxMap: Map<string, string[]>) {
       mxRecords,
       options: {
         ports: [25, 587],
-        timeout: 2000,
+        perAttemptTimeoutMs: 2000,
         cache: getDefaultCache(),
         debug: false,
       },
@@ -89,7 +89,7 @@ async function debugVerify(email: string, mxRecords: string[]) {
     mxRecords,
     options: {
       debug: true,
-      timeout: 5000,
+      perAttemptTimeoutMs: 5000,
       cache: null, // No caching
     },
   });
@@ -105,7 +105,7 @@ async function tryPortOnly(email: string, mxRecords: string[], port: number) {
     mxRecords,
     options: {
       ports: [port],
-      timeout: 3000,
+      perAttemptTimeoutMs: 3000,
       debug: true,
     },
   });

--- a/src/batch-verifier.ts
+++ b/src/batch-verifier.ts
@@ -9,7 +9,11 @@ export async function verifyEmailBatch(params: BatchVerifyParams): Promise<Batch
   const {
     emailAddresses,
     concurrency = 5,
-    timeout = 4000,
+    smtpPerAttemptTimeoutMs = 4000,
+    smtpTotalDeadlineMs,
+    smtpMaxConsecutiveFailures,
+    smtpMaxMxHosts,
+    smtpRetry,
     verifyMx = true,
     verifySmtp = false,
     checkDisposable = true,
@@ -42,7 +46,11 @@ export async function verifyEmailBatch(params: BatchVerifyParams): Promise<Batch
       try {
         const result = await verifyEmail({
           emailAddress: email,
-          timeout,
+          smtpPerAttemptTimeoutMs,
+          smtpTotalDeadlineMs,
+          smtpMaxConsecutiveFailures,
+          smtpMaxMxHosts,
+          smtpRetry,
           verifyMx,
           verifySmtp,
           checkDisposable,

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -53,7 +53,7 @@ export async function run(args: ParsedArgs, deps: CliRunDeps = {}): Promise<numb
     emailAddress: args.email,
     verifyMx: args.verifyMx,
     verifySmtp: args.verifySmtp,
-    timeout: args.timeoutMs ?? 5000,
+    smtpPerAttemptTimeoutMs: args.timeoutMs ?? 5000,
     debug: args.debug,
     smtpPort: args.smtpPort,
     checkDisposable: args.checkDisposable,
@@ -62,7 +62,7 @@ export async function run(args: ParsedArgs, deps: CliRunDeps = {}): Promise<numb
     suggestDomain: args.suggestDomain,
     checkDomainAge: args.checkDomainAge,
     checkDomainRegistration: args.checkDomainRegistration,
-    whoisTimeout: args.whoisTimeoutMs ?? 5000,
+    whoisTimeoutMs: args.whoisTimeoutMs ?? 5000,
     captureTranscript: args.captureTranscript,
   });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,6 +46,13 @@ export {
   detectNameForAlgorithm,
   detectNameFromEmail,
 } from './name-detector';
+// Recommended-config presets for serverless / dedicated / batch / fast workloads.
+export {
+  SMTP_PRESETS,
+  type SmtpPresetName,
+  VERIFY_EMAIL_PRESETS,
+  type VerifyEmailPresetName,
+} from './presets';
 export { refineReasonByEnhancedStatus } from './refine-reason';
 export { type ParsedSmtpError, parseSmtpError } from './smtp-error-parser';
 export { type ParsedDsn, parseDsn, verifyMailboxSMTP } from './smtp-verifier';

--- a/src/presets.ts
+++ b/src/presets.ts
@@ -1,0 +1,150 @@
+/**
+ * Recommended `verifyEmail` / `verifyMailboxSMTP` configuration presets for
+ * common deployment shapes.
+ *
+ * These are not magic — every value is just a `SMTPVerifyOptions` /
+ * `VerifyEmailParams` field with a sensible default for that workload.
+ * Use them directly, or spread + override:
+ *
+ *     await verifyEmail({
+ *       emailAddress: 'foo@bar.com',
+ *       ...VERIFY_EMAIL_PRESETS.serverless,
+ *     });
+ *
+ *     // Or override one field:
+ *     await verifyEmail({
+ *       emailAddress: 'foo@bar.com',
+ *       ...VERIFY_EMAIL_PRESETS.serverless,
+ *       smtpTotalDeadlineMs: 3000,
+ *     });
+ *
+ * Two parallel sets are exported:
+ *
+ *   - `SMTP_PRESETS`        — `SMTPVerifyOptions` shape, for callers using
+ *                             `verifyMailboxSMTP` directly.
+ *   - `VERIFY_EMAIL_PRESETS` — `VerifyEmailParams` shape, with the `smtp`-
+ *                             prefixed field names that `verifyEmail` uses.
+ *
+ * Presets:
+ *
+ *   - `serverless` — tight latency budget. Cuts off bad MXes fast.
+ *                    Suitable for Lambda / Vercel / Cloudflare-Workers
+ *                    request handlers with sub-10s SLAs.
+ *   - `dedicated`  — long-running server. Willing to retry once and wait
+ *                    longer. Suitable for a dedicated worker / dyno that
+ *                    isn't latency-bound.
+ *   - `batch`      — running through millions of addresses, accuracy more
+ *                    important than per-call latency. Multiple retries with
+ *                    exponential backoff, generous timeouts.
+ *   - `fast`       — favor speed over coverage. Single MX, single retry,
+ *                    short deadlines. For autocomplete / form-validation
+ *                    UX where the answer is needed in <2s.
+ */
+
+import type { SMTPVerifyOptions, VerifyEmailParams } from './types';
+
+/**
+ * Presets for `verifyMailboxSMTP`'s `options` field. Each preset is a
+ * subset of `SMTPVerifyOptions` — spread it and override fields as needed.
+ */
+export const SMTP_PRESETS = {
+  /**
+   * **Serverless** — Lambda / Vercel / Cloudflare-Workers handlers.
+   *
+   * Tight latency budget; cuts off bad MXes fast. The total wall-clock
+   * is bounded at 5 s so the probe finishes well inside a typical 10 s
+   * handler SLA, leaving headroom for everything else the handler does.
+   */
+  serverless: {
+    perAttemptTimeoutMs: 2500,
+    totalDeadlineMs: 5000,
+    maxConsecutiveFailures: 3,
+    maxMxHosts: 2,
+  } as const satisfies SMTPVerifyOptions,
+
+  /**
+   * **Dedicated** — long-running server / worker.
+   *
+   * Not latency-bound. Tries every MX, retries connection-class failures
+   * once with a 500 ms backoff. Suitable for an always-on backend that
+   * processes verification requests as they arrive.
+   */
+  dedicated: {
+    perAttemptTimeoutMs: 5000,
+    totalDeadlineMs: 30_000,
+    retry: { attempts: 1, delayMs: 500, backoff: 'exponential' },
+  } as const satisfies SMTPVerifyOptions,
+
+  /**
+   * **Batch** — bulk processing.
+   *
+   * Each address can take a while; what matters is correctness across
+   * the whole batch. Multiple retries with exponential backoff to ride
+   * out transient network blips. Generous per-attempt budget so slow
+   * MXes get a fair shot.
+   */
+  batch: {
+    perAttemptTimeoutMs: 10_000,
+    totalDeadlineMs: 60_000,
+    retry: { attempts: 2, delayMs: 1_000, backoff: 'exponential' },
+  } as const satisfies SMTPVerifyOptions,
+
+  /**
+   * **Fast** — UX-bound (form autocomplete / signup-form validation).
+   *
+   * Optimize for speed; accept that ambiguous results may be more common.
+   * Tries the primary MX only, single retry, sub-3s wall-clock.
+   */
+  fast: {
+    perAttemptTimeoutMs: 1500,
+    totalDeadlineMs: 3000,
+    maxConsecutiveFailures: 2,
+    maxMxHosts: 1,
+  } as const satisfies SMTPVerifyOptions,
+} as const;
+
+/**
+ * Presets for `verifyEmail`'s top-level params. Each preset is a subset of
+ * `VerifyEmailParams` — spread it and override fields as needed. The keys
+ * use the `smtp`-prefixed names that `verifyEmail` accepts (matching the
+ * unprefixed `SMTP_PRESETS` field-for-field).
+ */
+export const VERIFY_EMAIL_PRESETS = {
+  /** See `SMTP_PRESETS.serverless`. */
+  serverless: {
+    smtpPerAttemptTimeoutMs: 2500,
+    smtpTotalDeadlineMs: 5000,
+    smtpMaxConsecutiveFailures: 3,
+    smtpMaxMxHosts: 2,
+    whoisTimeoutMs: 3000,
+  } as const satisfies Partial<VerifyEmailParams>,
+
+  /** See `SMTP_PRESETS.dedicated`. */
+  dedicated: {
+    smtpPerAttemptTimeoutMs: 5000,
+    smtpTotalDeadlineMs: 30_000,
+    smtpRetry: { attempts: 1, delayMs: 500, backoff: 'exponential' },
+    whoisTimeoutMs: 5000,
+  } as const satisfies Partial<VerifyEmailParams>,
+
+  /** See `SMTP_PRESETS.batch`. */
+  batch: {
+    smtpPerAttemptTimeoutMs: 10_000,
+    smtpTotalDeadlineMs: 60_000,
+    smtpRetry: { attempts: 2, delayMs: 1_000, backoff: 'exponential' },
+    whoisTimeoutMs: 8000,
+  } as const satisfies Partial<VerifyEmailParams>,
+
+  /** See `SMTP_PRESETS.fast`. */
+  fast: {
+    smtpPerAttemptTimeoutMs: 1500,
+    smtpTotalDeadlineMs: 3000,
+    smtpMaxConsecutiveFailures: 2,
+    smtpMaxMxHosts: 1,
+    whoisTimeoutMs: 2000,
+  } as const satisfies Partial<VerifyEmailParams>,
+} as const;
+
+/** Type-level sugar for picking a preset by name. */
+export type SmtpPresetName = keyof typeof SMTP_PRESETS;
+export type VerifyEmailPresetName = keyof typeof VERIFY_EMAIL_PRESETS;

--- a/src/smtp-verifier.ts
+++ b/src/smtp-verifier.ts
@@ -125,14 +125,22 @@ export async function verifyMailboxSMTP(
   // Filter out non-integer / out-of-range ports — net.connect throws RangeError
   // synchronously for those, which would crash the promise executor.
   const ports = (options.ports ?? DEFAULT_PORTS).filter((port) => Number.isInteger(port) && port > 0 && port < 65536);
-  const timeout = options.timeout ?? DEFAULT_TIMEOUT_MS;
-  const tlsConfig = options.tls ?? true;
-  const hostname = options.hostname ?? 'localhost';
+  const perAttemptTimeoutMs = options.perAttemptTimeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const tlsConfig = options.tlsConfig ?? true;
+  const heloHostname = options.heloHostname ?? 'localhost';
   const debug = options.debug ?? false;
   const captureTranscript = options.captureTranscript ?? false;
   const sequence = options.sequence;
   const cache = options.cache;
   const log = debug ? (...args: unknown[]) => console.log('[SMTP]', ...args) : () => {};
+
+  // Early-stop policy.
+  const totalDeadlineMs = options.totalDeadlineMs;
+  const maxConsecutiveFailures = options.maxConsecutiveFailures;
+  const maxMxHosts = options.maxMxHosts;
+  const retryAttempts = options.retry?.attempts ?? 0;
+  const retryDelayMs = options.retry?.delayMs ?? 200;
+  const retryBackoff = options.retry?.backoff ?? 'exponential';
 
   const startedAtMs = Date.now();
 
@@ -150,9 +158,9 @@ export async function verifyMailboxSMTP(
   const probeOptions: ProbeOptions = {
     local,
     domain,
-    timeout,
+    perAttemptTimeoutMs,
     tlsConfig,
-    hostname,
+    heloHostname,
     sequence,
     log,
     catchAllProbeLocal: options.catchAllProbeLocal,
@@ -178,11 +186,42 @@ export async function verifyMailboxSMTP(
   const mxHostsTried: string[] = [];
   let mxAttempts = 0;
   let portAttempts = 0;
+  let consecutiveFailures = 0;
   let lastReason = 'all_attempts_failed';
   let lastEnhancedStatus: string | undefined;
   let lastResponseCode: number | undefined;
+  let stoppedEarly: 'deadline' | 'consecutive_failures' | 'max_mx_hosts' | null = null;
 
-  for (const mxHost of mxRecords) {
+  /** Connection-class outcomes count toward `maxConsecutiveFailures`; everything else resets it. */
+  const isConnectionFailure = (reason: string): boolean =>
+    reason === 'connection_error' ||
+    reason === 'connection_timeout' ||
+    reason === 'connection_closed' ||
+    reason === 'socket_timeout';
+
+  /** Compute backoff delay for the Nth retry (1-indexed). */
+  const retryDelayFor = (attemptIndex: number): number =>
+    retryBackoff === 'exponential' ? retryDelayMs * 2 ** (attemptIndex - 1) : retryDelayMs;
+
+  /** Run one probe attempt with optional retries on connection-class failures. */
+  const probeWithRetry = async (mxHost: string, port: number): Promise<ProbeResult> => {
+    let lastProbe = await runProbe({ ...probeOptions, mxHost, port });
+    for (let i = 1; i <= retryAttempts; i++) {
+      if (lastProbe.result !== null || !isConnectionFailure(lastProbe.reason)) break;
+      const delay = retryDelayFor(i);
+      log(`retry ${i}/${retryAttempts} on ${mxHost}:${port} after ${delay}ms (last: ${lastProbe.reason})`);
+      await new Promise((r) => setTimeout(r, delay));
+      portAttempts++;
+      lastProbe = await runProbe({ ...probeOptions, mxHost, port });
+    }
+    return lastProbe;
+  };
+
+  outer: for (const mxHost of mxRecords) {
+    if (maxMxHosts !== undefined && mxAttempts >= maxMxHosts) {
+      stoppedEarly = 'max_mx_hosts';
+      break;
+    }
     mxHostsTried.push(mxHost);
     mxAttempts++;
 
@@ -191,9 +230,13 @@ export async function verifyMailboxSMTP(
       mxHost === primaryMx && cachedPort ? [cachedPort, ...ports.filter((p) => p !== cachedPort)] : ports;
 
     for (const port of portsForThisMx) {
+      if (totalDeadlineMs !== undefined && Date.now() - startedAtMs >= totalDeadlineMs) {
+        stoppedEarly = 'deadline';
+        break outer;
+      }
       portAttempts++;
       log(`Testing ${mxHost}:${port}`);
-      const probe = await runProbe({ ...probeOptions, mxHost, port });
+      const probe = await probeWithRetry(mxHost, port);
       collectTranscript(transcript, commands, probe, mxHost, port);
       lastReason = probe.reason;
       if (probe.enhancedStatus !== undefined) lastEnhancedStatus = probe.enhancedStatus;
@@ -212,8 +255,16 @@ export async function verifyMailboxSMTP(
         if (mxHost === primaryMx) await safeCacheSet(portCache, primaryMx, port);
         return { smtpResult, cached: false, port, portCached: cachedPort === port };
       }
+
+      // Track consecutive connection-class failures for the early-stop policy.
+      consecutiveFailures = isConnectionFailure(probe.reason) ? consecutiveFailures + 1 : 0;
+      if (maxConsecutiveFailures !== undefined && consecutiveFailures >= maxConsecutiveFailures) {
+        stoppedEarly = 'consecutive_failures';
+        break outer;
+      }
     }
   }
+  if (stoppedEarly) log(`Stopped early: ${stoppedEarly}`);
 
   // Every MX×port returned indeterminate — surface the LAST attempt's reason
   // so callers can see the failure mode (e.g. tls_error tells a different
@@ -324,9 +375,9 @@ async function safeCacheSet<T>(
 interface ProbeOptions {
   local: string;
   domain: string;
-  timeout: number;
+  perAttemptTimeoutMs: number;
   tlsConfig: boolean | SMTPTLSConfig;
-  hostname: string;
+  heloHostname: string;
   sequence?: SMTPSequence;
   log: (...args: unknown[]) => void;
   catchAllProbeLocal?: SMTPVerifyOptions['catchAllProbeLocal'];
@@ -472,18 +523,18 @@ class SMTPProbeConnection {
     } else {
       this.socket = net.connect({ host: this.p.mxHost, port: this.p.port }, onConnect);
     }
-    this.socket.setTimeout(this.p.timeout, () => this.finish(null, 'socket_timeout'));
+    this.socket.setTimeout(this.p.perAttemptTimeoutMs, () => this.finish(null, 'socket_timeout'));
     this.socket.on('error', () => this.finish(null, 'connection_error'));
     this.socket.on('close', () => this.finish(null, 'connection_closed'));
   }
 
   private armConnectionTimer(): void {
-    this.connectionTimer = setTimeout(() => this.finish(null, 'connection_timeout'), this.p.timeout);
+    this.connectionTimer = setTimeout(() => this.finish(null, 'connection_timeout'), this.p.perAttemptTimeoutMs);
   }
 
   private resetStepTimer(): void {
     if (this.stepTimer) clearTimeout(this.stepTimer);
-    this.stepTimer = setTimeout(() => this.finish(null, 'step_timeout'), this.p.timeout);
+    this.stepTimer = setTimeout(() => this.finish(null, 'step_timeout'), this.p.perAttemptTimeoutMs);
   }
 
   private onData = (data: Buffer | string): void => {
@@ -521,10 +572,10 @@ class SMTPProbeConnection {
       case SMTPStep.greeting:
         return; // server-driven; nothing to send
       case SMTPStep.ehlo:
-        this.send(`EHLO ${this.p.hostname}`);
+        this.send(`EHLO ${this.p.heloHostname}`);
         return;
       case SMTPStep.helo:
-        this.send(`HELO ${this.p.hostname}`);
+        this.send(`HELO ${this.p.heloHostname}`);
         return;
       case SMTPStep.startTls:
         this.executeStartTls();
@@ -611,7 +662,7 @@ class SMTPProbeConnection {
       this.supportsStartTls = false;
       this.supportsPipelining = false;
       this.postUpgradeReEhlo = true;
-      this.send(`EHLO ${this.p.hostname}`);
+      this.send(`EHLO ${this.p.heloHostname}`);
     });
 
     this.socket = tlsSocket;
@@ -622,7 +673,7 @@ class SMTPProbeConnection {
       this.finish(null, this.tlsUpgrading ? 'tls_handshake_failed' : 'connection_error');
     });
     this.socket.on('close', () => this.finish(null, 'connection_closed'));
-    this.socket.setTimeout(this.p.timeout, () => this.finish(null, 'socket_timeout'));
+    this.socket.setTimeout(this.p.perAttemptTimeoutMs, () => this.finish(null, 'socket_timeout'));
   }
 
   /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -81,56 +81,147 @@ export interface VerificationResult {
 }
 
 /**
- * Parameters for email verification
+ * Parameters for `verifyEmail` — the high-level orchestrator that runs the
+ * full pipeline (syntax → typo / name / domain → disposable / free → WHOIS
+ * → MX → SMTP).
  */
 export interface VerifyEmailParams {
+  /** The full email address to verify (`local@domain`). */
   emailAddress: string;
-  timeout?: number;
+  // ── Step toggles (each defaults are listed inline) ────────────────────────
+  /** Resolve MX records via DNS to confirm the domain accepts mail. Default: `true`. */
   verifyMx?: boolean;
+  /** Open an SMTP connection to the highest-priority MX and probe `RCPT TO`. Default: `false`. */
   verifySmtp?: boolean;
-  debug?: boolean;
-  smtpPort?: number;
+  /** Check the address against the bundled disposable-provider list. Default: `true`. */
   checkDisposable?: boolean;
+  /** Check the address against the bundled free-provider list. Default: `true`. */
   checkFree?: boolean;
+  /** Extract first/last name from the local-part. Default: `false` (cheap, but not free). */
   detectName?: boolean;
-  nameDetectionMethod?: NameDetectionMethod;
+  /** Suggest a corrected domain on typos (e.g. `gnail.com` → `gmail.com`). Default: `true`. */
   suggestDomain?: boolean;
-  domainSuggestionMethod?: DomainSuggestionMethod;
-  commonDomains?: string[];
+  /** Look up the domain creation date via WHOIS. Slow + external dep. Default: `false`. */
   checkDomainAge?: boolean;
+  /** Look up domain registration status (registered / expired / locked). Default: `false`. */
   checkDomainRegistration?: boolean;
-  whoisTimeout?: number;
-  skipMxForDisposable?: boolean;
-  skipDomainWhoisForDisposable?: boolean;
-  cache?: Cache;
+  // ── Skip-on-disposable shortcuts ────────────────────────────────────────
   /**
-   * When true, populates `result.transcript` with a per-step trace covering
-   * every subsystem (syntax / disposable / free / MX / SMTP / WHOIS / name
-   * detection / domain suggestion). Each step records timing + step-specific
-   * structured details. Safe to leave off for production; turn on for
-   * diagnostics or building debug UIs.
+   * When the address is identified as disposable, skip the (expensive) MX +
+   * SMTP probe and accept the disposable verdict as the final answer.
+   * Default: `false`.
+   */
+  skipMxForDisposable?: boolean;
+  /**
+   * When the address is identified as disposable, skip the WHOIS checks too.
+   * Default: `false`.
+   */
+  skipDomainWhoisForDisposable?: boolean;
+  // ── Custom strategies (extension points for callers) ──────────────────────
+  /** Override the default name-detection heuristic. Receives the email; returns `DetectedName | null`. */
+  nameDetectionMethod?: NameDetectionMethod;
+  /** Override the default domain-suggestion heuristic. Receives the domain; returns `DomainSuggestion | null`. */
+  domainSuggestionMethod?: DomainSuggestionMethod;
+  /** Custom domain list for the typo suggester. Defaults to the bundled common-domain set. */
+  commonDomains?: string[];
+  // ── SMTP probe wiring ─────────────────────────────────────────────────────
+  /**
+   * Per-attempt timeout for the SMTP probe, in milliseconds. Bounds both the
+   * TCP/TLS connection setup AND the inactivity gap between SMTP commands
+   * within an attempt. Default: `4000` ms.
+   *
+   * To bound the total wall-clock across all MX × port attempts, use
+   * `smtpTotalDeadlineMs` instead. To control retries on connection-class
+   * failures, use `smtpRetry`.
+   */
+  smtpPerAttemptTimeoutMs?: number;
+  /**
+   * Hard cap on total wall-clock time for the SMTP probe across all MX × port
+   * × retry attempts. Reasonable when calling from a request handler with a
+   * tight latency budget. Default: unbounded.
+   */
+  smtpTotalDeadlineMs?: number;
+  /**
+   * Stop the SMTP probe after this many connection-class failures in a row
+   * (counting `connection_error` / `connection_timeout` / `connection_closed`
+   * across MX × port attempts). Resets on any non-connection-class outcome.
+   * Default: unbounded.
+   */
+  smtpMaxConsecutiveFailures?: number;
+  /**
+   * Hard cap on how many MX hostnames the SMTP probe will try, regardless of
+   * how many DNS returned. Default: unbounded — try them all.
+   */
+  smtpMaxMxHosts?: number;
+  /** Optional retry policy for connection-class failures on a single MX × port. Default: no retries. */
+  smtpRetry?: RetryPolicy;
+  /**
+   * Force a specific port for the SMTP probe (e.g. `587`). When set, this
+   * port is the only one tried — overrides the default `[25, 587, 465]` walk
+   * and any per-MX hint cached from a previous probe.
+   */
+  smtpPort?: number;
+  // ── WHOIS probe wiring ────────────────────────────────────────────────────
+  /** Per-WHOIS-query timeout in milliseconds. Default: `5000`. */
+  whoisTimeoutMs?: number;
+  // ── Caching + diagnostics ────────────────────────────────────────────────
+  /** Optional shared cache for MX, WHOIS, disposable / free, SMTP, and domain results. */
+  cache?: Cache;
+  /** When true, the pipeline writes a per-line trace to `console.debug`. Default: `false`. */
+  debug?: boolean;
+  /**
+   * When true, populates `result.transcript` with a per-step structured trace
+   * covering every subsystem (syntax / disposable / free / MX / SMTP / WHOIS /
+   * name detection / domain suggestion). Each step records timing +
+   * step-specific details (raw WHOIS data, SMTP transcript, MX records, cache
+   * hit/miss, etc.). Safe to leave off for production; turn on for diagnostics
+   * or debug UIs. Default: `false`.
    */
   captureTranscript?: boolean;
 }
 
 /**
- * Parameters for batch verification
+ * Parameters for `verifyEmailBatch` — fan-out wrapper around `verifyEmail`
+ * that runs many addresses through the same pipeline with a concurrency cap.
  */
 export interface BatchVerifyParams {
+  /** Email addresses to verify, in order. */
   emailAddresses: string[];
+  /** Maximum number of in-flight `verifyEmail` calls. Default: `5`. */
   concurrency?: number;
-  timeout?: number;
+  /** Per-attempt SMTP timeout in milliseconds (forwarded to each `verifyEmail` call). Default: `4000`. */
+  smtpPerAttemptTimeoutMs?: number;
+  /** Hard cap on total wall-clock for each individual SMTP probe. Forwarded to `verifyEmail`. */
+  smtpTotalDeadlineMs?: number;
+  /** Stop each individual SMTP probe after this many connection-class failures in a row. */
+  smtpMaxConsecutiveFailures?: number;
+  /** Hard cap on MX hostnames per individual SMTP probe. */
+  smtpMaxMxHosts?: number;
+  /** Optional retry policy per MX×port for each individual SMTP probe. */
+  smtpRetry?: RetryPolicy;
+  /** Resolve MX records per address. Default: `true`. */
   verifyMx?: boolean;
+  /** Run the SMTP probe per address. Default: `false`. */
   verifySmtp?: boolean;
+  /** Check disposable list per address. Default: `true`. */
   checkDisposable?: boolean;
+  /** Check free-provider list per address. Default: `true`. */
   checkFree?: boolean;
+  /** Extract first/last name from each local-part. Default: `false`. */
   detectName?: boolean;
+  /** Override the name-detection heuristic. */
   nameDetectionMethod?: NameDetectionMethod;
+  /** Suggest a corrected domain on typos. Default: `false` for batches (it's per-call cost). */
   suggestDomain?: boolean;
+  /** Override the domain-suggestion heuristic. */
   domainSuggestionMethod?: DomainSuggestionMethod;
+  /** Custom canonical-domain list for the typo suggester. */
   commonDomains?: string[];
+  /** Skip MX/SMTP probe for disposable addresses. Default: `false`. */
   skipMxForDisposable?: boolean;
+  /** Skip WHOIS lookups for disposable addresses. Default: `false`. */
   skipDomainWhoisForDisposable?: boolean;
+  /** Optional shared cache (re-used across all addresses in the batch). */
   cache?: Cache;
 }
 
@@ -313,47 +404,176 @@ export interface SMTPSequence {
   from?: string;
 }
 
+/**
+ * Optional retry policy for connection-class failures (timeout / connection
+ * error / connection closed) on a single MX × port. Definitive answers
+ * (250 / 550 / 552 / etc.) are never retried — they're stable verdicts.
+ */
+export interface RetryPolicy {
+  /**
+   * How many extra attempts to make on the same MX × port after a
+   * connection-class failure. `0` means no retry (the default).
+   */
+  attempts: number;
+  /**
+   * Delay between retries, in milliseconds. With `backoff: 'exponential'`
+   * (the default), the actual delay is `delayMs * 2^(attemptIndex - 1)`.
+   * Default: `200` ms.
+   */
+  delayMs?: number;
+  /**
+   * Backoff strategy between retries.
+   * - `'exponential'` (default): `delayMs * 2^(attemptIndex - 1)`.
+   * - `'fixed'`: every retry waits `delayMs` exactly.
+   */
+  backoff?: 'exponential' | 'fixed';
+}
+
+/**
+ * Options for `verifyMailboxSMTP` and `verifyEmail`'s SMTP probe.
+ *
+ * Time-budget defaults are tuned for a 4-MX × 3-port worst case. If you
+ * call this from a request handler with a tight latency budget, set
+ * `totalDeadlineMs` so the probe gives up before your handler does.
+ */
 export interface SMTPVerifyOptions {
+  // ── Connection envelope ───────────────────────────────────────────────────
+  /**
+   * Ports to walk per MX, in priority order. The probe stops on the first
+   * port that yields a definitive answer; indeterminate outcomes (timeout /
+   * connection error / etc.) fall through to the next port.
+   *
+   * Default: `[25, 587, 465]` — plain → STARTTLS-able → implicit-TLS.
+   */
   ports?: number[];
-  timeout?: number;
-  tls?: boolean | SMTPTLSConfig;
-  hostname?: string;
+  /**
+   * Per-attempt timeout in milliseconds. Bounds both the TCP/TLS connection
+   * setup AND the inactivity gap between SMTP commands within an attempt.
+   * Each MX × port pair gets its own budget — to bound the total wall-clock,
+   * use `totalDeadlineMs` instead.
+   *
+   * Default: `3000` ms.
+   */
+  perAttemptTimeoutMs?: number;
+  /**
+   * TLS configuration applied to implicit-TLS ports (465) and to STARTTLS
+   * upgrades on plaintext ports.
+   *
+   * - `true` (default): use sensible TLS defaults (`rejectUnauthorized: false`,
+   *   `minVersion: 'TLSv1.2'`) — picks up CA quirks of long-tail MXes.
+   * - `false`: disable TLS entirely (port 465 will fail to handshake; STARTTLS
+   *   step is skipped).
+   * - `SMTPTLSConfig` object: override individual fields. Merged onto the defaults.
+   */
+  tlsConfig?: boolean | SMTPTLSConfig;
+  /**
+   * Hostname this client identifies itself as in the `EHLO` / `HELO` argument.
+   * Should be a real FQDN — `localhost` from a public IP is a textbook spam-bot
+   * signature and gets rejected by careful MXes.
+   *
+   * Default: `'localhost'`. Override with your delivery domain in production.
+   */
+  heloHostname?: string;
+  // ── Caching ──────────────────────────────────────────────────────────────
+  /**
+   * Optional cache instance. When provided, the probe reuses prior verdicts
+   * keyed on `<primary mx>:<local>@<domain>` and remembers the last
+   * successful port per primary MX (so a re-probe skips the failed-port
+   * walk).
+   *
+   * Pass `null` or omit to skip caching entirely.
+   */
   cache?: Cache | null;
+  /**
+   * When true, a per-line `[SMTP] …` trace is written to `console.log`.
+   * Useful for diagnosing real-MX behavior; off by default for production.
+   */
   debug?: boolean;
   /**
-   * When true, the returned `SmtpVerificationResult` carries `transcript` and
-   * `commands` arrays prefixed with `<host>:<port>|s| …` / `<host>:<port>|c| …`.
-   * Aggregated across every MX×port attempted.
+   * When true, the returned `SmtpVerificationResult` carries `transcript`
+   * and `commands` arrays prefixed with `<host>:<port>|s| …` /
+   * `<host>:<port>|c| …`. Aggregated across every MX × port attempted.
    *
-   * Default: `false`. The strings are O(N×wire-bytes); skip when you don't
-   * need the trace.
+   * Default: `false`. The strings are O(N × wire-bytes); skip when you
+   * don't need the trace.
    */
   captureTranscript?: boolean;
+  // ── Time budget + early-stop policy ───────────────────────────────────────
+  /**
+   * Hard cap on total wall-clock time for the entire probe (across all
+   * MX × port × retry attempts). When the deadline passes, the in-flight
+   * attempt is allowed to finish (it has its own per-attempt budget) and
+   * no new attempts are started.
+   *
+   * Use this to bound latency from a request-handler caller. A reasonable
+   * value matches your handler's deadline minus headroom for everything
+   * else it does.
+   *
+   * Default: unbounded — only `perAttemptTimeoutMs × ports.length × mxRecords.length`
+   * limits the worst case (e.g. `3000 × 3 × 4 = 36s`).
+   */
+  totalDeadlineMs?: number;
+  /**
+   * Stop probing after this many connection-class failures in a row.
+   * Counts consecutive `connection_error` / `connection_timeout` /
+   * `connection_closed` outcomes across MX × port attempts; resets on any
+   * non-connection-class outcome. Useful for cutting off probes when the
+   * network path to the MX is wholly unreachable instead of waiting for
+   * every port × MX combination to time out.
+   *
+   * Default: unbounded.
+   */
+  maxConsecutiveFailures?: number;
+  /**
+   * Hard cap on how many MX hostnames to try, regardless of how many were
+   * supplied in `mxRecords`. The probe walks them in priority order
+   * (`mxRecords[0]` first) and stops after this many.
+   *
+   * Default: unbounded.
+   */
+  maxMxHosts?: number;
+  /**
+   * Optional retry policy for connection-class failures on a single MX × port.
+   * Definitive answers (250 / 550 / 552 / 421 / etc.) are never retried —
+   * they're stable verdicts.
+   *
+   * Default: no retries.
+   */
+  retry?: RetryPolicy;
+  // ── Dialogue customization ───────────────────────────────────────────────
+  /**
+   * Override the per-attempt SMTP step list. Defaults to
+   * `[greeting, ehlo, startTls, mailFrom, rcptTo]` — covering the entire
+   * RFC 5321 envelope plus optional TLS upgrade. Most callers never need
+   * to override this; useful for advanced testing scenarios (e.g. probe
+   * RFC compliance with `[greeting, helo, mailFrom, rcptTo]`).
+   */
   sequence?: SMTPSequence;
   /**
-   * Override the random-local-part generator used by the catch-all probe.
-   * Useful for deterministic tests; receives the real local-part and domain
-   * so callers can derive a probe-local that matches the MX's syntax rules.
+   * Override the random local-part generator used by the catch-all dual
+   * probe. Useful for deterministic tests; receives the real local-part
+   * and domain so callers can derive a probe-local that matches the MX's
+   * syntax rules.
    *
    * Default: `<16 hex chars>-noexist` — long enough to never collide,
-   * structured so it's clearly synthetic and passes common syntax filters.
+   * structured so it's clearly synthetic, and passes common syntax filters.
    */
   catchAllProbeLocal?: (realLocal: string, domain: string) => string;
   /**
-   * Use SMTP PIPELINING (RFC 2920) to batch the envelope phase
+   * SMTP PIPELINING (RFC 2920) — batch the envelope phase
    * (RCPT TO real + RCPT TO probe + RSET) into one `socket.write()` when
    * the MX advertises support.
    *
-   * - `'auto'` (default): pipeline when EHLO multi-line includes
-   *   `PIPELINING`, sequential otherwise.
+   * - `'auto'` (default): pipeline when EHLO multi-line includes `PIPELINING`,
+   *   sequential otherwise.
    * - `'never'`: always sequential — useful for deterministic wire-level
-   *   assertions in tests, or when investigating a flaky pipeline-buggy MX.
+   *   assertions in tests or when investigating a pipeline-buggy MX.
    * - `'force'`: pipeline without checking — testing escape hatch.
    */
   pipelining?: 'auto' | 'never' | 'force';
   /**
-   * Controls STARTTLS upgrade on plaintext ports (25, 587). Implicit-TLS
-   * ports (465) ignore this option — they're already TLS from the start.
+   * STARTTLS upgrade on plaintext ports (25, 587). Implicit-TLS ports (465)
+   * ignore this option — they're already TLS from the start.
    *
    * - `'auto'` (default): upgrade if the MX advertises STARTTLS in EHLO.
    *   Submission-port (587) MXes typically require this — without it,

--- a/src/verify-email.ts
+++ b/src/verify-email.ts
@@ -202,14 +202,14 @@ async function runWhoisChecks(
     log(`[verifyEmail] WHOIS checks skipped for disposable: ${domain}`);
     return;
   }
-  const whoisTimeout = params.whoisTimeout ?? 5000;
+  const whoisTimeoutMs = params.whoisTimeoutMs ?? 5000;
   const debug = params.debug ?? false;
 
   if (params.checkDomainAge) {
     try {
       result.domainAge = await collector.record(
         'whois-age',
-        () => getDomainAge(domain, whoisTimeout, debug, params.cache),
+        () => getDomainAge(domain, whoisTimeoutMs, debug, params.cache),
         (info) => ({
           domain,
           found: info !== null,
@@ -230,7 +230,7 @@ async function runWhoisChecks(
     try {
       result.domainRegistration = await collector.record(
         'whois-registration',
-        () => getDomainRegistrationStatus(domain, whoisTimeout, debug, params.cache),
+        () => getDomainRegistrationStatus(domain, whoisTimeoutMs, debug, params.cache),
         (info) => ({
           domain,
           found: info !== null,
@@ -324,7 +324,11 @@ async function runSmtp(
           options: {
             cache: params.cache,
             ports: resolveSmtpPorts(params.smtpPort, mxRecords[0]),
-            timeout: params.timeout ?? 4000,
+            perAttemptTimeoutMs: params.smtpPerAttemptTimeoutMs ?? 4000,
+            totalDeadlineMs: params.smtpTotalDeadlineMs,
+            maxConsecutiveFailures: params.smtpMaxConsecutiveFailures,
+            maxMxHosts: params.smtpMaxMxHosts,
+            retry: params.smtpRetry,
             debug: params.debug ?? false,
             // Forward transcript capture so the SMTP step's details include
             // the full per-port transcript when the caller asked for it.


### PR DESCRIPTION
## Why

The user's debug log showed nine `connection_timeout` attempts to Yahoo's MXes (3 hosts × 3 ports) totaling ~27 seconds with no way to bail early. This release adds the missing knobs and tightens param names so it's obvious what each controls without reading the code.

## What changed

### New SMTP control options (additive)

All opt-in. Defaults preserve current behavior.

| Option | Behavior |
| --- | --- |
| `totalDeadlineMs` | Hard cap on total wall-clock. Once elapsed, no new attempts are started. |
| `maxConsecutiveFailures` | Stop after N connection-class failures in a row (resets on non-connection outcomes). |
| `maxMxHosts` | Limit MX walk to first N hostnames regardless of DNS results. |
| `retry: { attempts, delayMs?, backoff? }` | Retry connection-class failures on the same MX×port. Definitive answers (250 / 550 / 552) are never retried. Backoff is `'exponential'` (default) or `'fixed'`. |

`VerifyEmailParams` re-exports these with an `smtp` prefix: `smtpTotalDeadlineMs`, `smtpMaxConsecutiveFailures`, `smtpMaxMxHosts`, `smtpRetry`.

### Renames (BREAKING)

For clarity. No aliases — TypeScript will flag every old name with a `Did you mean…?` hint.

| Before | After | Why |
| --- | --- | --- |
| `SMTPVerifyOptions.timeout` | `perAttemptTimeoutMs` | Per-MX×port budget; units in name |
| `SMTPVerifyOptions.tls` | `tlsConfig` | Matches `SMTPTLSConfig` type name |
| `SMTPVerifyOptions.hostname` | `heloHostname` | What it actually is — the EHLO/HELO identity |
| `VerifyEmailParams.timeout` | `smtpPerAttemptTimeoutMs` | Scope (SMTP only) + units in name |
| `VerifyEmailParams.whoisTimeout` | `whoisTimeoutMs` | Units in name |
| `BatchVerifyParams.timeout` | `smtpPerAttemptTimeoutMs` | Same as above |

### JSDoc every option

`SMTPVerifyOptions`, `VerifyEmailParams`, `BatchVerifyParams` now have a JSDoc block on every field that:
- says what the option controls in one line
- lists the default value
- explains when each value is the right choice (for enum-like options)
- cross-references related options (use `totalDeadlineMs` to bound wall-clock, `perAttemptTimeoutMs` to bound a single attempt)

Fields grouped into sections (Connection envelope / Caching / Time budget + early-stop / Dialogue customization) so the interface reads top-down in the order callers care about.

## Tests

- `__tests__/unit/0117-smtp-control-options.test.ts` — 7 new tests covering each option's decision path:
  - `totalDeadlineMs` aborts mid-walk
  - `maxConsecutiveFailures` stops after N failures
  - counter resets on non-connection-class outcomes
  - `maxMxHosts` caps the MX walk
  - `retry` runs N extra attempts
  - retry is skipped on definitive answers
  - exponential backoff doubles delays

- All existing tests + examples updated for the new field names (sed sweep over `__tests__/unit/`, `__tests__/integration/`, `examples/`).

## Verification

- [x] `bun run typecheck` — clean
- [x] `bun run test` — 807 unit + 37 isolated tests passing
- [x] `bun run test:extras` — 206 / 1 skip / 0 fail
- [x] `bun run build` — zero rollup warnings, all bundles produced

## Migration

For callers of `verifyEmail` / `verifyMailboxSMTP`, the diff is mechanical:

```diff
  await verifyEmail({
    emailAddress: 'alice@example.com',
    verifyMx: true,
    verifySmtp: true,
-   timeout: 5000,
-   whoisTimeout: 3000,
+   smtpPerAttemptTimeoutMs: 5000,
+   whoisTimeoutMs: 3000,
+   smtpTotalDeadlineMs: 8000,         // NEW: bound total SMTP wall-clock
+   smtpMaxConsecutiveFailures: 3,     // NEW: stop after 3 timeouts in a row
+   smtpRetry: { attempts: 1 },        // NEW: one retry on connection-class failures
  });
```

For the user's Yahoo-timeout case from the log:
```ts
await verifyEmail({
  emailAddress: 'maria.hernandez+news@yahoo.com',
  verifySmtp: true,
  smtpTotalDeadlineMs: 5000,         // bail after 5s total
  smtpMaxConsecutiveFailures: 3,     // OR after 3 timeouts in a row
});
// Returns isDeliverable: false, error: 'connection_timeout' in ~5s
// instead of grinding through 9 attempts × 3s = 27s.
```

## Merge note

This is `feat!:` with a `BREAKING CHANGE:` footer — semantic-release will publish a major bump on merge. Use a regular merge commit (or rebase-and-merge), not squash, so the conventional-commit message survives.